### PR TITLE
Add more optional stylings

### DIFF
--- a/lib/flutter_html.dart
+++ b/lib/flutter_html.dart
@@ -12,6 +12,7 @@ class Html extends StatelessWidget {
     this.defaultTextStyle = const TextStyle(color: Colors.black),
     this.onLinkTap,
     this.renderNewlines = false,
+    this.customRender,
   }) : super(key: key);
 
   final String data;
@@ -20,6 +21,10 @@ class Html extends StatelessWidget {
   final TextStyle defaultTextStyle;
   final Function onLinkTap;
   final bool renderNewlines;
+
+  /// Either return a custom widget for specific node types or return null to
+  /// fallback to the default rendering.
+  final CustomRender customRender;
 
   @override
   Widget build(BuildContext context) {
@@ -37,6 +42,7 @@ class Html extends StatelessWidget {
             width: width,
             onLinkTap: onLinkTap,
             renderNewlines: renderNewlines,
+            customRender: customRender,
           ).parse(data),
         ),
       ),

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -2,16 +2,20 @@ import 'package:flutter/material.dart';
 import 'package:html/parser.dart' as parser;
 import 'package:html/dom.dart' as dom;
 
+typedef CustomRender = Widget Function(dom.Node node, List<Widget> children);
+
 class HtmlParser {
   HtmlParser({
     @required this.width,
     this.onLinkTap,
     this.renderNewlines = false,
+    this.customRender,
   });
 
   final double width;
   final Function onLinkTap;
   final bool renderNewlines;
+  final CustomRender customRender;
 
   static const _supportedElements = [
     "a",
@@ -93,9 +97,14 @@ class HtmlParser {
     List<Widget> widgetList = new List<Widget>();
 
     if (renderNewlines) {
-      print("Before: $data");
+      assert(() {
+        print("Before: $data");
+        return true;
+      }());
       data = data.replaceAll("\n", "<br />");
-      print("After: $data");
+      assert(() {
+        print("After: $data");
+      }());
     }
     dom.Document document = parser.parse(data);
     widgetList.add(_parseNode(document.body));
@@ -103,11 +112,24 @@ class HtmlParser {
   }
 
   Widget _parseNode(dom.Node node) {
+    if (customRender != null) {
+      final Widget customWidget =
+          customRender(node, _parseNodeList(node.nodes));
+      if (customWidget != null) {
+        return customWidget;
+      }
+    }
+
     if (node is dom.Element) {
-      print("Found ${node.localName}");
+      assert(() {
+        print("Found ${node.localName}");
+        return true;
+      }());
+
       if (!_supportedElements.contains(node.localName)) {
         return Container();
       }
+
       switch (node.localName) {
         case "a":
           return GestureDetector(


### PR DESCRIPTION
Hi, thanks for this awesome flutter package. It really helps us a lot to display HTML pages.

However I needed a couple more customisation options. A callback to render a custom Image widget is very useful to be able to apply stylings (rounded borders) or to add network headers and so on.

Apart from that I wanted to apply some specific text paddings and styles.

I also put the `print` call into an `assert` block so that this is not constantly logging in a production environment. But for dev, it totally make sense.