### PR TITLE
Update html_parser.dart

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -498,12 +498,24 @@ class HtmlParser {
               mark = Container(width: 0.0, height: 0.0);
               break;
           }
+//           return Container(
+//             width: width,
+//             child: Wrap(
+//               children: <Widget>[
+//                 mark,
+//                 Wrap(children: _parseNodeList(node.nodes))
+//               ],
+//             ),
+//           );
           return Container(
-            width: width,
-            child: Wrap(
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
                 mark,
-                Wrap(children: _parseNodeList(node.nodes))
+                Container(
+                  width: width / 1.2,
+                    child: Wrap(
+                        children: _parseNodeList(node.nodes)))
               ],
             ),
           );


### PR DESCRIPTION
Fix layout when use number list and dot list html 
![errorhtml](https://user-images.githubusercontent.com/2025287/48882962-ecf36000-ee4f-11e8-95a2-bbae349420ff.jpeg)
