### PR TITLE
use preCacheImage to catch errors while image loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.9.7] - March 26, 2019:
+
+* Added onImageError callback
+
 ## [0.9.6] - March 11, 2019:
 
 * Fix whitespace issue. ([#59](https://github.com/Sub6Resources/flutter_html/issues/59))

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Flutter widget for rendering static html tags as Flutter widgets. (Will render
 Add the following to your `pubspec.yaml` file:
 
     dependencies:
-      flutter_html: ^0.9.6
+      flutter_html: ^0.9.7
 
 ## Currently Supported HTML Tags:
 `a`, `abbr`, `acronym`, `address`, `article`, `aside`, `b`, `bdi`, `bdo`, `big`, `blockquote`, `body`, `br`, `caption`, `cite`, `code`, `data`, `dd`, `del`, `dfn`, `div`, `dl`, `dt`, `em`, `figcaption`, `figure`, `footer`, `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `header`, `hr`, `i`, `img`, `ins`, `kbd`, `li`, `main`, `mark`, `nav`, `noscript`, `ol`, `p`, `pre`, `q`, `rp`, `rt`, `ruby`, `s`, `samp`, `section`, `small`, `span`, `strike`, `strong`, `sub`, `sup`, `table`, `tbody`, `td`, `template`, `tfoot`, `th`, `thead`, `time`, `tr`, `tt`, `u`, `ul`, `var`

--- a/lib/flutter_html.dart
+++ b/lib/flutter_html.dart
@@ -15,6 +15,7 @@ class Html extends StatelessWidget {
     this.customRender,
     this.blockSpacing = 14.0,
     this.useRichText = false,
+    this.onImageError,
   }) : super(key: key);
 
   final String data;
@@ -25,6 +26,7 @@ class Html extends StatelessWidget {
   final bool renderNewlines;
   final double blockSpacing;
   final bool useRichText;
+  final ImageErrorListener onImageError;
 
   /// Either return a custom widget for specific node types or return null to
   /// fallback to the default rendering.
@@ -46,6 +48,7 @@ class Html extends StatelessWidget {
                 onLinkTap: onLinkTap,
                 renderNewlines: renderNewlines,
                 html: data,
+                onImageError: onImageError,
               )
             : HtmlOldParser(
                 width: width,

--- a/lib/flutter_html.dart
+++ b/lib/flutter_html.dart
@@ -57,6 +57,7 @@ class Html extends StatelessWidget {
                 customRender: customRender,
                 html: data,
                 blockSpacing: blockSpacing,
+                onImageError: onImageError,
               ),
       ),
     );

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -144,6 +144,7 @@ class HtmlRichTextParser extends StatelessWidget {
     this.onLinkTap,
     this.renderNewlines = false,
     this.html,
+    this.onImageError,
   });
 
   final double indentSize = 10.0;
@@ -152,6 +153,7 @@ class HtmlRichTextParser extends StatelessWidget {
   final onLinkTap;
   final bool renderNewlines;
   final String html;
+  final ImageErrorListener onImageError;
 
   // style elements set a default style
   // for all child nodes
@@ -628,9 +630,7 @@ class HtmlRichTextParser extends StatelessWidget {
                     ),
                   ),
                   buildContext,
-                  onError: (_, stacktrace) {
-                    print(stacktrace);
-                  },
+                  onError: onImageError,
                 );
                 parseContext.rootWidgetList.add(Image.memory(base64.decode(
                     node.attributes['src'].split("base64,")[1].trim())));
@@ -638,9 +638,7 @@ class HtmlRichTextParser extends StatelessWidget {
                 precacheImage(
                   NetworkImage(node.attributes['src']),
                   buildContext,
-                  onError: (_, stacktrace) {
-                    print(stacktrace);
-                  },
+                  onError: onImageError,
                 );
                 parseContext.rootWidgetList
                     .add(Image.network(node.attributes['src']));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_html
 description: A Flutter widget for rendering static html tags as Flutter widgets. (Will render over 70 different html tags!)
-version: 0.9.6
+version: 0.9.7
 author: Matthew Whitaker <sub6resources@gmail.com>
 homepage: https://github.com/Sub6Resources/flutter_html
 


### PR DESCRIPTION
The used Image.network throws errors without an opinion to handle them (for example when the Statuscode != 200). preCacheImage provides an official way to handle such errors. The benefit in my case is, that errors aren't reported to sentry.