### PR TITLE
Added custom textstyle and edgeinsets callback

### DIFF
--- a/lib/flutter_html.dart
+++ b/lib/flutter_html.dart
@@ -13,6 +13,8 @@ class Html extends StatelessWidget {
     this.onLinkTap,
     this.renderNewlines = false,
     this.customRender,
+    this.customEdgeInsets,
+    this.customTextStyle,
     this.blockSpacing = 14.0,
     this.useRichText = false,
   }) : super(key: key);
@@ -29,6 +31,8 @@ class Html extends StatelessWidget {
   /// Either return a custom widget for specific node types or return null to
   /// fallback to the default rendering.
   final CustomRender customRender;
+  final CustomEdgeInsets customEdgeInsets;
+  final CustomTextStyle customTextStyle;
 
   @override
   Widget build(BuildContext context) {
@@ -45,6 +49,8 @@ class Html extends StatelessWidget {
                 width: width,
                 onLinkTap: onLinkTap,
                 renderNewlines: renderNewlines,
+                customEdgeInsets: customEdgeInsets,
+                customTextStyle: customTextStyle,
                 html: data,
               )
             : HtmlOldParser(


### PR DESCRIPTION
Hi, first of all: really great work, I really appreciate it!
For a recent project we were missing the possibility to change the textstyle and the margins of specific elements when we use the "useRichText" flag. 
I implemented CustomEdgeInsets and CustomTextStyle callbacks in the style of your CustomRender to provide custom textstyles to the element and margins to the containing BlockText object.

The CustomTextStyle callback supplies the node and the childStyle, so we can use the childStyle to modify it (e.g. change color depending of a css class) or simply create a completely different style.