### PR TITLE
adding ability to disable using width and height attributes in img tag

### DIFF
--- a/lib/image_properties.dart
+++ b/lib/image_properties.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 class ImageProperties {
   final String semanticLabel;
   final bool excludeFromSemantics;
+  final bool useWidthAttribute;
+  final bool useHeightAttribute;
   final double width;
   final double height;
   final Color color;
@@ -20,6 +22,8 @@ class ImageProperties {
     this.scale = 1,
     this.semanticLabel,
     this.excludeFromSemantics = false,
+    this.useWidthAttribute = true,
+    this.useHeightAttribute = true,
     this.width,
     this.height,
     this.color,

--- a/lib/rich_text_parser.dart
+++ b/lib/rich_text_parser.dart
@@ -739,12 +739,16 @@ class HtmlRichTextParser extends StatelessWidget {
             if (showImages) {
               if (node.attributes['src'] != null) {
                 final width = imageProperties?.width ??
-                    ((node.attributes['width'] != null)
-                        ? double.tryParse(node.attributes['width'])
+                    (imageProperties?.useWidthAttribute ?? true
+                        ? (node.attributes['width'] != null)
+                            ? double.tryParse(node.attributes['width'])
+                            : null
                         : null);
                 final height = imageProperties?.height ??
-                    ((node.attributes['height'] != null)
-                        ? double.tryParse(node.attributes['height'])
+                    (imageProperties?.useHeightAttribute ?? true
+                        ? (node.attributes['height'] != null)
+                            ? double.tryParse(node.attributes['height'])
+                            : null
                         : null);
 
                 if (node.attributes['src'].startsWith("data:image") &&
@@ -788,7 +792,8 @@ class HtmlRichTextParser extends StatelessWidget {
                     },
                   ));
                 } else if (node.attributes['src'].startsWith('asset:')) {
-                  final assetPath = node.attributes['src'].replaceFirst('asset:', '');
+                  final assetPath =
+                      node.attributes['src'].replaceFirst('asset:', '');
                   precacheImage(
                     AssetImage(assetPath),
                     buildContext,


### PR DESCRIPTION
extra parameters added to image properties for letting user choose to use or not to use the width and height attributes in `img` tag.
the main reason for this change is that the pixels in web is different with flutter. But the html is made for web not for flutter so with this parameter we are able to control this.

I have set the default value for this added parameters to true so that package's behavior won't change. But I personally think that this parameters default value should be false.