### PR TITLE
Ensures that text is scaled properly using accessibility fonts. 

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -64,7 +64,15 @@ class HtmlParser extends StatelessWidget {
       cleanedTree,
     );
 
-    return StyledText(textSpan: parsedTree, style: cleanedTree.style);
+    // This is the final scaling that assumes any other StyledText instances are
+    // using textScaleFactor = 1.0 (which is the default). This ensures the correct
+    // scaling is used, but relies on https://github.com/flutter/flutter/pull/59711
+    // to wrap everything when larger accessibility fonts are used.
+    return StyledText(
+      textSpan: parsedTree, 
+      style: cleanedTree.style,
+      textScaleFactor: MediaQuery.of(context).textScaleFactor,
+    );
   }
 
   /// [parseHTML] converts a string of HTML to a DOM document using the dart `html` library.
@@ -703,10 +711,12 @@ class ContainerSpan extends StatelessWidget {
 class StyledText extends StatelessWidget {
   final InlineSpan textSpan;
   final Style style;
+  final double textScaleFactor;
 
   const StyledText({
     this.textSpan,
     this.style,
+    this.textScaleFactor = 1.0,
   });
 
   @override
@@ -721,6 +731,7 @@ class StyledText extends StatelessWidget {
         style: style.generateTextStyle(),
         textAlign: style.textAlign,
         textDirection: style.direction,
+        textScaleFactor: textScaleFactor,
       ),
     );
   }


### PR DESCRIPTION
This resolves https://github.com/Sub6Resources/flutter_html/issues/308, but as noted in the comment does rely on https://github.com/flutter/flutter/pull/59711. That fix is currently in the `master` channel, but I'm not sure when it will find its way out into the `stable` release.

| Normal font | Larger font |
|---|---|
| ![Simulator Screen Shot - iPhone 11 - 2020-06-20 at 15 46 09](https://user-images.githubusercontent.com/1574429/85193636-c1777680-b30d-11ea-9f11-9ea7e1d33cde.png) | ![Simulator Screen Shot - iPhone 11 - 2020-06-20 at 15 46 20](https://user-images.githubusercontent.com/1574429/85193637-c5a39400-b30d-11ea-86db-54785a011057.png) |
