### PR TITLE
Added support to skip custom render-er if is null

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -245,7 +245,7 @@ class HtmlParser extends StatelessWidget {
             newContext: newContext,
             style: tree.style,
             shrinkWrap: context.parser.shrinkWrap,
-            child: builder,
+            child: customRenderForElement,
           ),
         );
       }

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -224,27 +224,31 @@ class HtmlParser extends StatelessWidget {
     );
 
     if (customRender?.containsKey(tree.name) ?? false) {
-      return WidgetSpan(
-        child: ContainerSpan(
+      dynamic customRenderForElement = customRender[tree.name].call(
+        newContext,
+        ContainerSpan(
           newContext: newContext,
           style: tree.style,
           shrinkWrap: context.parser.shrinkWrap,
-          child: customRender[tree.name].call(
-            newContext,
-            ContainerSpan(
-              newContext: newContext,
-              style: tree.style,
-              shrinkWrap: context.parser.shrinkWrap,
-              children: tree.children
-                      ?.map((tree) => parseTree(newContext, tree))
-                      ?.toList() ??
-                  [],
-            ),
-            tree.attributes,
-            tree.element,
-          ),
+          children: tree.children
+                  ?.map((tree) => parseTree(newContext, tree))
+                  ?.toList() ??
+              [],
         ),
+        tree.attributes,
+        tree.element,
       );
+
+      if (customRenderForElement != null) {
+        return WidgetSpan(
+          child: ContainerSpan(
+            newContext: newContext,
+            style: tree.style,
+            shrinkWrap: context.parser.shrinkWrap,
+            child: builder,
+          ),
+        );
+      }
     }
 
     //Return the correct InlineSpan based on the element type.


### PR DESCRIPTION
These changes allow skipping the custom render-er and using back the default render-er in some cases, 

by returning a null value or not returning any value from the function "customRender".