### PR TITLE
Table: make `width` property not mandatory on `<col>` elements.

### DIFF
--- a/lib/src/layout_element.dart
+++ b/lib/src/layout_element.dart
@@ -40,7 +40,7 @@ class TableLayoutElement extends LayoutElement {
               return FractionColumnWidth(width);
             } else {
               final width = double.tryParse(widthStr);
-              return FixedColumnWidth(width);
+              return width != null ? FixedColumnWidth(width) : null;
             }
           });
         })


### PR DESCRIPTION
This makes the `width` property not mandatory on `<col>` elements.
e.g. on a table with 2 columns, you can now specify the width of the 1st column, but not the 2nd, so the 2nd one will automatically take all the remaining width space.

Actually if you don't specify a `width` on all or some of the `<col>` elements, you get an error where `Failed assertion: line 133 pos 47: 'value != null': is not true.`