### PR TITLE
Revert "Remove remaining leading and trailing whitespaces"

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -69,7 +69,7 @@ class HtmlParser extends StatelessWidget {
     // scaling is used, but relies on https://github.com/flutter/flutter/pull/59711
     // to wrap everything when larger accessibility fonts are used.
     return StyledText(
-      textSpan: parsedTree,
+      textSpan: parsedTree, 
       style: cleanedTree.style,
       textScaleFactor: MediaQuery.of(context).textScaleFactor,
     );
@@ -439,15 +439,13 @@ class HtmlParser extends StatelessWidget {
   /// (2) Replace all newlines with a space
   /// (3) Replace all tabs with a space
   /// (4) Replace any instances of two or more spaces with a single space.
-  /// (5) Remove remaining leading and trailing spaces.
   static String _removeUnnecessaryWhitespace(String text) {
     return text
         .replaceAll(RegExp("\ *(?=\n)"), "\n")
         .replaceAll(RegExp("(?:\n)\ *"), "\n")
         .replaceAll("\n", " ")
         .replaceAll("\t", " ")
-        .replaceAll(RegExp(" {2,}"), " ")
-        .trim();
+        .replaceAll(RegExp(" {2,}"), " ");
   }
 
   /// [processListCharacters] adds list characters to the front of all list items.

--- a/test/html_parser_test.dart
+++ b/test/html_parser_test.dart
@@ -19,25 +19,6 @@ void main() {
     );
   });
 
-  testWidgets("Parser trims whitepaces", (WidgetTester tester) async {
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Html(
-            data: """
-              <div>
-                content
-              </div>
-            """,
-          ),
-        ),
-      ),
-    );
-    expect(find.byType(Html), findsOneWidget);
-    expect(find.text("content"), findsOneWidget);
-    expect(find.text(" content "), findsNothing);
-  });
-
   testNewParser();
 }
 


### PR DESCRIPTION
Reverts Sub6Resources/flutter_html#398

This change solved issues with leading spaces, but at the same time introduced a regression with required spaces within blocks (inline elements) to be removed.