### PR TITLE
Temporary fix for irregular table rows

### DIFF
--- a/lib/src/styled_element.dart
+++ b/lib/src/styled_element.dart
@@ -12,6 +12,7 @@ class StyledElement {
   List<StyledElement> children;
   Style style;
   final dom.Node _node;
+  int differenceBetweenLargest = 0;
 
   StyledElement({
     this.name = "[[No name]]",
@@ -19,6 +20,7 @@ class StyledElement {
     this.elementClasses,
     this.children,
     this.style,
+    this.differenceBetweenLargest,
     dom.Element node,
   }) : this._node = node;
 


### PR DESCRIPTION
Possible temporary fix for #242 . Definitely needs testing, but in two test cases this worked fine.

Basically what I did was find the row(s) that had the most number of elements, and store their length. 
Then, just before building the table, create a list of empty containers that corresponds to the difference between the length of the row being built and the length of the longest row(s).
Finally, attach that empty container list into the `TableRow` `children` property to avoid the irregular sizing error.

I left my `print` statements in for debugging if this solution doesn't work for certain cases.