### PR TITLE
Images consume the screen height if the source is larger than needed

### DIFF
--- a/lib/src/replaced_element.dart
+++ b/lib/src/replaced_element.dart
@@ -155,7 +155,6 @@ class ImageContentElement extends ReplacedElement {
             return new Image.network(
               src,
               width: snapshot.data.width,
-              height: snapshot.data.height,
               frameBuilder: (ctx, child, frame, _) {
                 if (frame == null) {
                   return Text(alt ?? "", style: context.style.generateTextStyle());


### PR DESCRIPTION
Fix #485 where images consume the screen height if the source is larger than the available space