### PR TITLE
Support InlineSpan as customRender

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -81,7 +81,7 @@ const htmlData = """
       <tr><td>fData</td><td>fData</td><td>fData</td></tr>
       </tfoot>
       </table>
-      <h3>Custom Element Support:</h3>
+      <h3>Custom Element Support (inline: <bird></bird> and as block):</h3>
       <flutter></flutter>
       <flutter horizontal></flutter>
       <h3>SVG support:</h3>
@@ -122,7 +122,6 @@ const htmlData = """
       <p>
         <img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' />
         <a href='https://google.com'><img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' /></a>
-        <img alt='Alt Text of an intentionally broken image' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30d' />
       </p>
       <h3>Video support:</h3>
       <video controls>
@@ -173,6 +172,9 @@ class _MyHomePageState extends State<MyHomePage> {
             "var": Style(fontFamily: 'serif'),
           },
           customRender: {
+            "bird": (RenderContext context, Widget child, attributes, _) {
+              return TextSpan(text: "🐦");
+            },
             "flutter": (RenderContext context, Widget child, attributes, _) {
               return FlutterLogo(
                 style: (attributes['horizontal'] != null)

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -257,8 +257,8 @@ class HtmlParser extends StatelessWidget {
         tree.attributes,
         tree.element,
       );
-      assert(render is InlineSpan || render is Widget);
       if (render != null) {
+        assert(render is InlineSpan || render is Widget);
         return render is InlineSpan
             ? render
             : WidgetSpan(

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -15,7 +15,7 @@ import 'package:html/parser.dart' as htmlparser;
 import 'package:webview_flutter/webview_flutter.dart';
 
 typedef OnTap = void Function(String url);
-typedef CustomRender = Widget Function(
+typedef CustomRender = dynamic Function(
   RenderContext context,
   Widget parsedChild,
   Map<String, String> attributes,
@@ -243,27 +243,31 @@ class HtmlParser extends StatelessWidget {
     );
 
     if (customRender?.containsKey(tree.name) ?? false) {
-      return WidgetSpan(
-        child: ContainerSpan(
+      final render = customRender[tree.name].call(
+        newContext,
+        ContainerSpan(
           newContext: newContext,
           style: tree.style,
           shrinkWrap: context.parser.shrinkWrap,
-          child: customRender[tree.name].call(
-            newContext,
-            ContainerSpan(
-              newContext: newContext,
-              style: tree.style,
-              shrinkWrap: context.parser.shrinkWrap,
-              children: tree.children
-                      ?.map((tree) => parseTree(newContext, tree))
-                      ?.toList() ??
-                  [],
-            ),
-            tree.attributes,
-            tree.element,
-          ),
+          children: tree.children
+                  ?.map((tree) => parseTree(newContext, tree))
+                  ?.toList() ??
+              [],
         ),
+        tree.attributes,
+        tree.element,
       );
+      assert(render is InlineSpan || render is Widget);
+      return render is InlineSpan
+          ? render
+          : WidgetSpan(
+              child: ContainerSpan(
+                newContext: newContext,
+                style: tree.style,
+                shrinkWrap: context.parser.shrinkWrap,
+                child: render,
+              ),
+            );
     }
 
     //Return the correct InlineSpan based on the element type.

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -258,16 +258,18 @@ class HtmlParser extends StatelessWidget {
         tree.element,
       );
       assert(render is InlineSpan || render is Widget);
-      return render is InlineSpan
-          ? render
-          : WidgetSpan(
-              child: ContainerSpan(
-                newContext: newContext,
-                style: tree.style,
-                shrinkWrap: context.parser.shrinkWrap,
-                child: render,
-              ),
-            );
+      if (render != null) {
+        return render is InlineSpan
+            ? render
+            : WidgetSpan(
+                child: ContainerSpan(
+                  newContext: newContext,
+                  style: tree.style,
+                  shrinkWrap: context.parser.shrinkWrap,
+                  child: render,
+                ),
+              );
+      }
     }
 
     //Return the correct InlineSpan based on the element type.


### PR DESCRIPTION
Same as #298 but only the minimal required changes to make this work.

```
          customRender: {
            "bird": (RenderContext context, Widget child, attributes, _) {
              return TextSpan(text: "🐦");
            },
          },
```

Side note: I noticed that custom renders only work for tags with a proper, separate closing tag (not self-closing) but I guess that is in line with the html spec (and an implementation of the html parser in the end).