### PR TITLE
Fix inline rendering of (text) links

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -120,8 +120,8 @@ const htmlData = """
       </p>
       <h3>Image support:</h3>
       <p>
-        <img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' />
-        <a href='https://google.com'><img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' /></a>
+        <img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' /><br />
+        <a href='https://google.com'>A linked image: <img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' /></a>
         <img alt='Alt Text of an intentionally broken image' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30d' />
       </p>
       <h3>Video support:</h3>

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -331,7 +331,6 @@ class HtmlParser extends StatelessWidget {
       }
     } else if (tree is InteractableElement) {
       return TextSpan(
-        style: newContext.style.generateTextStyle(),
         children: tree.children
                 .map((tree) => parseTree(newContext, tree))
                 .map((childSpan) {
@@ -339,7 +338,8 @@ class HtmlParser extends StatelessWidget {
                 return TextSpan(
                   text: childSpan.text,
                   children: childSpan.children,
-                  style: childSpan.style,
+                  style: (childSpan.style ?? TextStyle())
+                      .merge(newContext.style.generateTextStyle()),
                   semanticsLabel: childSpan.semanticsLabel,
                   recognizer: TapGestureRecognizer()
                     ..onTap = () => onLinkTap?.call(tree.href),
@@ -357,10 +357,11 @@ class HtmlParser extends StatelessWidget {
                         },
                       ),
                     },
-                    child: StyledText(
-                      style: newContext.style,
-                      textSpan: childSpan,
-                    ),
+                    child: (childSpan as WidgetSpan).child,
+                    // child: StyledText(
+                    //   style: newContext.style.copyWith(textDecoration: null),
+                    //   textSpan: childSpan,
+                    // ),
                   ),
                 );
               }

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -358,10 +358,6 @@ class HtmlParser extends StatelessWidget {
                       ),
                     },
                     child: (childSpan as WidgetSpan).child,
-                    // child: StyledText(
-                    //   style: newContext.style.copyWith(textDecoration: null),
-                    //   textSpan: childSpan,
-                    // ),
                   ),
                 );
               }

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:csslib/parser.dart' as cssparser;
 import 'package:csslib/visitor.dart' as css;
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_html/src/css_parser.dart';
@@ -329,28 +330,42 @@ class HtmlParser extends StatelessWidget {
         );
       }
     } else if (tree is InteractableElement) {
-      return WidgetSpan(
-        child: RawGestureDetector(
-          gestures: {
-            MultipleTapGestureRecognizer: GestureRecognizerFactoryWithHandlers<
-                MultipleTapGestureRecognizer>(
-              () => MultipleTapGestureRecognizer(),
-              (instance) {
-                instance..onTap = () => onLinkTap?.call(tree.href);
-              },
-            ),
-          },
-          child: StyledText(
-            textSpan: TextSpan(
-              style: newContext.style.generateTextStyle(),
-              children: tree.children
-                      .map((tree) => parseTree(newContext, tree))
-                      .toList() ??
-                  [],
-            ),
-            style: newContext.style,
-          ),
-        ),
+      return TextSpan(
+        style: newContext.style.generateTextStyle(),
+        children: tree.children
+                .map((tree) => parseTree(newContext, tree))
+                .map((childSpan) {
+              if (childSpan is TextSpan) {
+                return TextSpan(
+                  text: childSpan.text,
+                  children: childSpan.children,
+                  style: childSpan.style,
+                  semanticsLabel: childSpan.semanticsLabel,
+                  recognizer: TapGestureRecognizer()
+                    ..onTap = () => onLinkTap?.call(tree.href),
+                );
+              } else {
+                return WidgetSpan(
+                  child: RawGestureDetector(
+                    gestures: {
+                      MultipleTapGestureRecognizer:
+                          GestureRecognizerFactoryWithHandlers<
+                              MultipleTapGestureRecognizer>(
+                        () => MultipleTapGestureRecognizer(),
+                        (instance) {
+                          instance..onTap = () => onLinkTap?.call(tree.href);
+                        },
+                      ),
+                    },
+                    child: StyledText(
+                      style: newContext.style,
+                      textSpan: childSpan,
+                    ),
+                  ),
+                );
+              }
+            }).toList() ??
+            [],
       );
     } else if (tree is LayoutElement) {
       return WidgetSpan(


### PR DESCRIPTION
If non-text elements are used inside the <a> we still need widget spans and if they are long you can still have clunky wrapping, but I'm not even sure that is a bug per se.

<img width="300" alt="Screenshot 2021-01-15 at 12 48 49" src="https://user-images.githubusercontent.com/196453/104723757-05115200-5730-11eb-8f27-7ee1afe98066.png">

Fixes #388, #488 and #495