### PR TITLE
Add basic support for svg elements in <img>

### DIFF
--- a/lib/src/replaced_element.dart
+++ b/lib/src/replaced_element.dart
@@ -120,6 +120,8 @@ class ImageContentElement extends ReplacedElement {
           return child;
         },
       );
+    } else if (src.endsWith(".svg")) {
+      return SvgPicture.network(src);
     } else {
       precacheImage(
         NetworkImage(src),


### PR DESCRIPTION
Fixes #220 and possibly fixes #209 

I used ` <img alt='Alt Text' src='https://www.svgrepo.com/show/117055/small-duck.svg' />` to test this.

![image](https://user-images.githubusercontent.com/50850142/104825021-2acc5300-5825-11eb-81ac-4d00cfbd31da.png)
