### PR TITLE
Custom Image API

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,6 +35,12 @@ const htmlData = """
 <h4>Header 4</h4>
 <h5>Header 5</h5>
 <h6>Header 6</h6>
+ <p>
+  <img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' />
+  <a href='https://google.com'><img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' /></a>
+  <img alt='Alt Text of an intentionally broken image' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30d' />
+  <img alt='Alt Text of an intentionally broken image' src='/show/117055/small-duck.svg' />
+</p>
 <h3>Ruby Support:</h3>
       <p>
         <ruby>
@@ -118,11 +124,6 @@ const htmlData = """
         Linking to <a href='https://github.com'>websites</a> has never been easier.
       </p>
       <h3>Image support:</h3>
-      <p>
-        <img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' />
-        <a href='https://google.com'><img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' /></a>
-        <img alt='Alt Text of an intentionally broken image' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30d' />
-      </p>
       <h3>Video support:</h3>
       <video controls>
         <source src="https://www.w3schools.com/html/mov_bbb.mp4" />
@@ -190,6 +191,17 @@ class _MyHomePageState extends State<MyHomePage> {
           },
           onImageError: (exception, stackTrace) {
             print(exception);
+          },
+          customImage: {
+            "google.com": CustomImage(
+                overrideImageLoader: LinearProgressIndicator(value: 50,),
+                overrideAltTextWidget: ListTile(leading: Icon(Icons.error), title: Text("There was an error while loading this image"),
+                )
+            ),
+            "small-duck.svg" : CustomImage(
+              suppressTaps: true,
+              pathPrefix: "https://svgrepo.com",
+            )
           },
         ),
       ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -195,7 +195,9 @@ class _MyHomePageState extends State<MyHomePage> {
           customImage: {
             "google.com": CustomImage(
                 overrideImageLoader: LinearProgressIndicator(value: 50,),
-                overrideAltTextWidget: ListTile(leading: Icon(Icons.error), title: Text("There was an error while loading this image"),
+                overrideAltTextWidget: ListTile(leading: Icon(Icons.error), title: Text("There was an error while loading this image")),
+                customImageOptions: CustomImageOptions(
+                  color: Colors.red
                 )
             ),
             "small-duck.svg" : CustomImage(

--- a/lib/flutter_html.dart
+++ b/lib/flutter_html.dart
@@ -42,6 +42,7 @@ class Html extends StatelessWidget {
     this.blacklistedElements = const [],
     this.style,
     this.navigationDelegateForIframe,
+    this.customImage,
   }) : super(key: key);
 
   final String data;
@@ -66,6 +67,11 @@ class Html extends StatelessWidget {
   /// to use NavigationDelegate.
   final NavigationDelegate navigationDelegateForIframe;
 
+  /// Provides custom options while rendering images. See [CustomImage] for currently supported options.
+  /// Set an exact image URL or a relative domain as a key in the map,
+  /// and use [CustomImage] as the value to define how images with that URL/domain should be rendered.
+  final Map<String, CustomImage> customImage;
+
   @override
   Widget build(BuildContext context) {
     final double width = shrinkWrap ? null : MediaQuery.of(context).size.width;
@@ -82,6 +88,7 @@ class Html extends StatelessWidget {
         customRender: customRender,
         blacklistedElements: blacklistedElements,
         navigationDelegateForIframe: navigationDelegateForIframe,
+        customImage: customImage,
       ),
     );
   }

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -33,6 +33,7 @@ class HtmlParser extends StatelessWidget {
   final Map<String, CustomRender> customRender;
   final List<String> blacklistedElements;
   final NavigationDelegate navigationDelegateForIframe;
+  final Map<String, CustomImage> customImage;
 
   HtmlParser({
     @required this.htmlData,
@@ -44,6 +45,7 @@ class HtmlParser extends StatelessWidget {
     this.customRender,
     this.blacklistedElements,
     this.navigationDelegateForIframe,
+    this.customImage,
   });
 
   @override
@@ -54,6 +56,7 @@ class HtmlParser extends StatelessWidget {
       customRender?.keys?.toList() ?? [],
       blacklistedElements,
       navigationDelegateForIframe,
+      customImage
     );
     StyledElement styledTree = applyCSS(lexedTree);
     StyledElement inlineStyledTree = applyInlineStyles(styledTree);
@@ -96,6 +99,7 @@ class HtmlParser extends StatelessWidget {
     List<String> customRenderTags,
     List<String> blacklistedElements,
     NavigationDelegate navigationDelegateForIframe,
+    Map<String, CustomImage> customImage,
   ) {
     StyledElement tree = StyledElement(
       name: "[Tree Root]",
@@ -109,6 +113,7 @@ class HtmlParser extends StatelessWidget {
         customRenderTags,
         blacklistedElements,
         navigationDelegateForIframe,
+        customImage
       ));
     });
 
@@ -124,6 +129,7 @@ class HtmlParser extends StatelessWidget {
     List<String> customRenderTags,
     List<String> blacklistedElements,
     NavigationDelegate navigationDelegateForIframe,
+    Map<String, CustomImage> customImage,
   ) {
     List<StyledElement> children = List<StyledElement>();
 
@@ -133,6 +139,7 @@ class HtmlParser extends StatelessWidget {
         customRenderTags,
         blacklistedElements,
         navigationDelegateForIframe,
+        customImage,
       ));
     });
 
@@ -146,7 +153,7 @@ class HtmlParser extends StatelessWidget {
       } else if (INTERACTABLE_ELEMENTS.contains(node.localName)) {
         return parseInteractableElement(node, children);
       } else if (REPLACED_ELEMENTS.contains(node.localName)) {
-        return parseReplacedElement(node, navigationDelegateForIframe);
+        return parseReplacedElement(node, navigationDelegateForIframe, customImage);
       } else if (LAYOUT_ELEMENTS.contains(node.localName)) {
         return parseLayoutElement(node, children);
       } else if (TABLE_CELL_ELEMENTS.contains(node.localName)) {
@@ -764,4 +771,36 @@ class StyledText extends StatelessWidget {
       ),
     );
   }
+}
+
+/// The [CustomImage] is a class that can define certain options when rendering <img> tags.
+///
+/// [CustomImage] supports setting headers when getting an image from a URL,
+/// ignoring taps on images, prefixing a certain path on images with relative paths,
+/// ignoring the width and height tags of images, overriding the image loader,
+/// overriding the set `Alt Text` for a broken image, or overriding the `Alt Text` widget itself.
+/// These changes can be on a per-image basis, by supplying an exact URL or just a relative domain
+/// in the [customImage] parameter of [Html].
+/// To apply a [CustomImage] to all images, use "." as the key.
+/// Make sure to put that key last in case you want to have a different [CustomImage] for certain domains.
+class CustomImage {
+  final Map<String, String> headers;
+  final bool suppressTaps;
+  final String pathPrefix;
+  final bool ignoreWidth;
+  final bool ignoreHeight;
+  final Widget overrideImageLoader;
+  final String overrideAltText;
+  final Widget overrideAltTextWidget;
+
+  const CustomImage({
+    this.headers,
+    this.suppressTaps,
+    this.pathPrefix,
+    this.ignoreWidth,
+    this.ignoreHeight,
+    this.overrideImageLoader,
+    this.overrideAltText,
+    this.overrideAltTextWidget,
+  });
 }

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -779,6 +779,8 @@ class StyledText extends StatelessWidget {
 /// ignoring taps on images, prefixing a certain path on images with relative paths,
 /// ignoring the width and height tags of images, overriding the image loader,
 /// overriding the set `Alt Text` for a broken image, or overriding the `Alt Text` widget itself.
+/// It also supports setting all the options for an [Image] widget or an [SvgPicture] widget with
+/// [CustomImageOptions] and [CustomSvgOptions], respectively.
 /// These changes can be on a per-image basis, by supplying an exact URL or just a relative domain
 /// in the [customImage] parameter of [Html].
 /// To apply a [CustomImage] to all images, use "." as the key.
@@ -792,6 +794,8 @@ class CustomImage {
   final Widget overrideImageLoader;
   final String overrideAltText;
   final Widget overrideAltTextWidget;
+  final CustomImageOptions customImageOptions;
+  final CustomSvgOptions customSvgOptions;
 
   const CustomImage({
     this.headers,
@@ -802,5 +806,73 @@ class CustomImage {
     this.overrideImageLoader,
     this.overrideAltText,
     this.overrideAltTextWidget,
+    this.customImageOptions,
+    this.customSvgOptions
+  });
+}
+
+/// The [CustomImageOptions] is a class that can define all the options for the [Image] widget when rendering <img> tags.
+class CustomImageOptions {
+  final double width;
+  final double height;
+  final Color color;
+  final FilterQuality filterQuality;
+  final BlendMode colorBlendMode;
+  final BoxFit fit;
+  final AlignmentGeometry alignment;
+  final ImageRepeat repeat;
+  final Rect centerSlice;
+  final bool matchTextDirection;
+  final bool gaplessPlayback;
+  final String semanticLabel;
+  final bool excludeFromSemantics;
+  final bool isAntiAlias;
+
+  CustomImageOptions({
+    this.width,
+    this.height,
+    this.color,
+    this.filterQuality,
+    this.colorBlendMode,
+    this.fit,
+    this.alignment,
+    this.repeat,
+    this.centerSlice,
+    this.matchTextDirection,
+    this.gaplessPlayback,
+    this.semanticLabel,
+    this.excludeFromSemantics,
+    this.isAntiAlias,
+  });
+}
+
+/// The [CustomSvgOptions] is a class that can define all the options for the [SvgPicture] widget when rendering <img> tags that have an svg as their src.
+class CustomSvgOptions {
+  final double width;
+  final double height;
+  final BoxFit fit;
+  final AlignmentGeometry alignment;
+  final bool matchTextDirection;
+  final bool allowDrawingOutsideViewBox;
+  final Color color;
+  final BlendMode colorBlendMode;
+  final String semanticsLabel;
+  final bool excludeFromSemantics;
+  final Clip clipBehavior;
+  final bool cacheColorFilter;
+
+  CustomSvgOptions({
+    this.allowDrawingOutsideViewBox,
+    this.semanticsLabel,
+    this.clipBehavior,
+    this.cacheColorFilter,
+    this.width,
+    this.height,
+    this.color,
+    this.colorBlendMode,
+    this.fit,
+    this.alignment,
+    this.matchTextDirection,
+    this.excludeFromSemantics,
   });
 }

--- a/lib/src/replaced_element.dart
+++ b/lib/src/replaced_element.dart
@@ -103,6 +103,20 @@ class ImageContentElement extends ReplacedElement {
       );
       imageWidget = Image.memory(
         decodedImage,
+        width: customOptions?.ignoreWidth == true ? null : customOptions?.customImageOptions?.width ?? null,
+        semanticLabel: customOptions?.customImageOptions?.semanticLabel ?? null,
+        excludeFromSemantics: customOptions?.customImageOptions?.excludeFromSemantics ?? false,
+        height: customOptions?.ignoreWidth == true ? null : customOptions?.customImageOptions?.width ?? null,
+        color: customOptions?.customImageOptions?.color ?? null,
+        colorBlendMode: customOptions?.customImageOptions?.colorBlendMode ?? null,
+        fit: customOptions?.customImageOptions?.fit ?? null,
+        alignment: customOptions?.customImageOptions?.alignment ?? Alignment.center,
+        repeat: customOptions?.customImageOptions?.repeat ?? ImageRepeat.noRepeat,
+        centerSlice: customOptions?.customImageOptions?.centerSlice ?? null,
+        matchTextDirection: customOptions?.customImageOptions?.matchTextDirection ?? false,
+        gaplessPlayback: customOptions?.customImageOptions?.gaplessPlayback ?? false,
+        filterQuality: customOptions?.customImageOptions?.filterQuality ?? FilterQuality.low,
+        isAntiAlias: customOptions?.customImageOptions?.isAntiAlias ?? false,
         frameBuilder: (ctx, child, frame, _) {
           if (frame == null) {
             return customOptions?.overrideAltTextWidget ?? Text(alt ?? customOptions?.overrideAltText ?? "", style: context.style.generateTextStyle());
@@ -121,6 +135,20 @@ class ImageContentElement extends ReplacedElement {
       );
       imageWidget = Image.asset(
         assetPath,
+        width: customOptions?.ignoreWidth == true ? null : customOptions?.customImageOptions?.width ?? null,
+        semanticLabel: customOptions?.customImageOptions?.semanticLabel ?? null,
+        excludeFromSemantics: customOptions?.customImageOptions?.excludeFromSemantics ?? false,
+        height: customOptions?.ignoreWidth == true ? null : customOptions?.customImageOptions?.width ?? null,
+        color: customOptions?.customImageOptions?.color ?? null,
+        colorBlendMode: customOptions?.customImageOptions?.colorBlendMode ?? null,
+        fit: customOptions?.customImageOptions?.fit ?? null,
+        alignment: customOptions?.customImageOptions?.alignment ?? Alignment.center,
+        repeat: customOptions?.customImageOptions?.repeat ?? ImageRepeat.noRepeat,
+        centerSlice: customOptions?.customImageOptions?.centerSlice ?? null,
+        matchTextDirection: customOptions?.customImageOptions?.matchTextDirection ?? false,
+        gaplessPlayback: customOptions?.customImageOptions?.gaplessPlayback ?? false,
+        filterQuality: customOptions?.customImageOptions?.filterQuality ?? FilterQuality.low,
+        isAntiAlias: customOptions?.customImageOptions?.isAntiAlias ?? false,
         frameBuilder: (ctx, child, frame, _) {
           if (frame == null) {
             return customOptions?.overrideAltTextWidget ?? Text(alt ?? customOptions?.overrideAltText ?? "", style: context.style.generateTextStyle());
@@ -129,8 +157,22 @@ class ImageContentElement extends ReplacedElement {
         },
       );
     } else if (newSrc.endsWith(".svg")) {
-      return SvgPicture.network(newSrc, headers: customOptions?.headers ?? null,
-          placeholderBuilder: (BuildContext context) => customOptions?.overrideImageLoader ?? CircularProgressIndicator());
+      imageWidget = SvgPicture.network(newSrc,
+          headers: customOptions?.headers ?? null,
+          placeholderBuilder: (BuildContext context) => customOptions?.overrideImageLoader ?? CircularProgressIndicator(),
+          width: customOptions?.ignoreWidth == true ? null : customOptions?.customSvgOptions?.width ?? null,
+          semanticsLabel: customOptions?.customSvgOptions?.semanticsLabel ?? null,
+          excludeFromSemantics: customOptions?.customSvgOptions?.excludeFromSemantics ?? false,
+          height: customOptions?.ignoreWidth == true ? null : customOptions?.customSvgOptions?.width ?? null,
+          color: customOptions?.customSvgOptions?.color ?? null,
+          colorBlendMode: customOptions?.customSvgOptions?.colorBlendMode ?? BlendMode.srcIn,
+          fit: customOptions?.customSvgOptions?.fit ?? BoxFit.contain,
+          alignment: customOptions?.customSvgOptions?.alignment ?? Alignment.center,
+          matchTextDirection: customOptions?.customSvgOptions?.matchTextDirection ?? false,
+          allowDrawingOutsideViewBox: customOptions?.customSvgOptions?.allowDrawingOutsideViewBox ?? false,
+          cacheColorFilter: customOptions?.customSvgOptions?.cacheColorFilter ?? false,
+          clipBehavior: customOptions?.customSvgOptions?.clipBehavior ?? Clip.hardEdge,
+      );
     } else {
       precacheImage(
         NetworkImage(newSrc, headers: customOptions?.headers ?? null),
@@ -166,7 +208,20 @@ class ImageContentElement extends ReplacedElement {
             return new Image.network(
               newSrc,
               headers: customOptions?.headers ?? null,
-              width: customOptions?.ignoreWidth == true ? null : snapshot.data.width,
+              width: customOptions?.ignoreWidth == true ? null : customOptions?.customImageOptions?.width ?? snapshot.data.width,
+              semanticLabel: customOptions?.customImageOptions?.semanticLabel ?? null,
+              excludeFromSemantics: customOptions?.customImageOptions?.excludeFromSemantics ?? false,
+              height: customOptions?.ignoreWidth == true ? null : customOptions?.customImageOptions?.width ?? null,
+              color: customOptions?.customImageOptions?.color ?? null,
+              colorBlendMode: customOptions?.customImageOptions?.colorBlendMode ?? null,
+              fit: customOptions?.customImageOptions?.fit ?? null,
+              alignment: customOptions?.customImageOptions?.alignment ?? Alignment.center,
+              repeat: customOptions?.customImageOptions?.repeat ?? ImageRepeat.noRepeat,
+              centerSlice: customOptions?.customImageOptions?.centerSlice ?? null,
+              matchTextDirection: customOptions?.customImageOptions?.matchTextDirection ?? false,
+              gaplessPlayback: customOptions?.customImageOptions?.gaplessPlayback ?? false,
+              filterQuality: customOptions?.customImageOptions?.filterQuality ?? FilterQuality.low,
+              isAntiAlias: customOptions?.customImageOptions?.isAntiAlias ?? false,
               frameBuilder: (ctx, child, frame, _) {
                 if (frame == null) {
                   return customOptions?.overrideAltTextWidget ?? Text(alt ?? customOptions?.overrideAltText ?? "", style: context.style.generateTextStyle());


### PR DESCRIPTION
Fixes #130, #153, #172, #301, #386.
Implements #146, #156, #183, #235, #278, #496.
Todo #162, #304, #478.

Discussion at #497 

See example/main.dart and html_parser.dart to see how the implementation works.
For those who are wishing for headers to be passed to images, please test this out against your use case and comment if you come across any issues.