### PR TITLE
Switch from chewie_audio to asset_audio_player

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Add the following to your `pubspec.yaml` file:
 
     dependencies:
       flutter_html: ^1.2.0
+      
+Note: Your iOS Minimum Deployment Target must be set to 9.0 (or above) to use `flutter_html`.
 
 ## Currently Supported HTML Tags:
 `a`, `abbr`, `acronym`, `address`, `article`, `aside`, `b`, `bdi`, `bdo`, `big`, `blockquote`, `body`, `br`, `caption`, `cite`, `code`, `data`, `dd`, `del`, `dfn`, `div`, `dl`, `dt`, `em`, `figcaption`, `figure`, `footer`, `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `header`, `hr`, `i`, `img`, `ins`, `kbd`, `li`, `main`, `mark`, `nav`, `noscript`, `ol`, `p`, `pre`, `q`, `rp`, `rt`, `ruby`, `s`, `samp`, `section`, `small`, `span`, `strike`, `strong`, `sub`, `sup`, `table`, `tbody`, `td`, `template`, `tfoot`, `th`, `thead`, `time`, `tr`, `tt`, `u`, `ul`, `var`

--- a/example/ios/Flutter/Flutter.podspec
+++ b/example/ios/Flutter/Flutter.podspec
@@ -1,18 +1,18 @@
 #
 # NOTE: This podspec is NOT to be published. It is only used as a local source!
+#       This is a generated file; do not edit or check into version control.
 #
 
 Pod::Spec.new do |s|
   s.name             = 'Flutter'
   s.version          = '1.0.0'
   s.summary          = 'High-performance, high-fidelity mobile apps.'
-  s.description      = <<-DESC
-Flutter provides an easy and productive way to build and deploy high-performance mobile apps for Android and iOS.
-                       DESC
   s.homepage         = 'https://flutter.io'
   s.license          = { :type => 'MIT' }
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
   s.ios.deployment_target = '8.0'
-  s.vendored_frameworks = 'Flutter.framework'
+  # Framework linking is handled by Flutter tooling, not CocoaPods.
+  # Add a placeholder to satisfy `s.dependency 'Flutter'` plugin podspecs.
+  s.vendored_frameworks = 'path/to/nothing'
 end

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -28,6 +28,9 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 end
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,11 @@
 PODS:
+  - assets_audio_player (0.0.1):
+    - Flutter
+  - assets_audio_player_web (0.0.1):
+    - Flutter
   - Flutter (1.0.0)
+  - path_provider (0.0.1):
+    - Flutter
   - video_player (0.0.1):
     - Flutter
   - wakelock (0.0.1):
@@ -8,14 +14,23 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - assets_audio_player (from `.symlinks/plugins/assets_audio_player/ios`)
+  - assets_audio_player_web (from `.symlinks/plugins/assets_audio_player_web/ios`)
   - Flutter (from `Flutter`)
+  - path_provider (from `.symlinks/plugins/path_provider/ios`)
   - video_player (from `.symlinks/plugins/video_player/ios`)
   - wakelock (from `.symlinks/plugins/wakelock/ios`)
   - webview_flutter (from `.symlinks/plugins/webview_flutter/ios`)
 
 EXTERNAL SOURCES:
+  assets_audio_player:
+    :path: ".symlinks/plugins/assets_audio_player/ios"
+  assets_audio_player_web:
+    :path: ".symlinks/plugins/assets_audio_player_web/ios"
   Flutter:
     :path: Flutter
+  path_provider:
+    :path: ".symlinks/plugins/path_provider/ios"
   video_player:
     :path: ".symlinks/plugins/video_player/ios"
   wakelock:
@@ -24,11 +39,14 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
+  assets_audio_player: edee322b9cb625571b830b35872ead1a295fd917
+  assets_audio_player_web: 19826380c44375761aa0b9053665c1e3fbc3b86b
+  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
+  path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
   video_player: 9cc823b1d9da7e8427ee591e8438bfbcde500e6e
   wakelock: bfc7955c418d0db797614075aabbc58a39ab5107
   webview_flutter: d2b4d6c66968ad042ad94cbb791f5b72b4678a96
 
-PODFILE CHECKSUM: 8e679eca47255a8ca8067c4c67aab20e64cb974d
+PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
 
-COCOAPODS: 1.10.0
+COCOAPODS: 1.10.0.beta.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		782AAE8A7E7C4461C8C3F120 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3304D71F8B052AE7479C9E9F /* Pods_Runner.framework */; };
 		9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9740EEB21CF90195004384FC /* Debug.xcconfig */; };
 		978B8F6F1D3862AE00F588F7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */; };
 		97C146F31CF9000F007C117D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 97C146F21CF9000F007C117D /* main.m */; };
@@ -34,6 +35,7 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		3304D71F8B052AE7479C9E9F /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		49DCEF6F09B6F3E8BBB9D4EA /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -57,7 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A65EE5648FB89B4FBB7BE7EF /* libPods-Runner.a in Frameworks */,
+				782AAE8A7E7C4461C8C3F120 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -67,7 +69,7 @@
 		092B7351CFBC8F0782F51612 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				49DCEF6F09B6F3E8BBB9D4EA /* libPods-Runner.a */,
+				3304D71F8B052AE7479C9E9F /* Pods_Runner.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -133,7 +135,6 @@
 				A7CDEE80872A41183CD903E6 /* Pods-Runner.release.xcconfig */,
 				F2E16627F28351910CCEBD53 /* Pods-Runner.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -151,7 +152,7 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				450FC00D9CC4F56F4423DF9E /* [CP] Embed Pods Frameworks */,
+				047C81F883396CD6340BAA05 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -173,6 +174,7 @@
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 1210;
 					};
 				};
 			};
@@ -210,6 +212,34 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		047C81F883396CD6340BAA05 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/assets_audio_player/assets_audio_player.framework",
+				"${BUILT_PRODUCTS_DIR}/assets_audio_player_web/assets_audio_player_web.framework",
+				"${BUILT_PRODUCTS_DIR}/path_provider/path_provider.framework",
+				"${BUILT_PRODUCTS_DIR}/video_player/video_player.framework",
+				"${BUILT_PRODUCTS_DIR}/wakelock/wakelock.framework",
+				"${BUILT_PRODUCTS_DIR}/webview_flutter/webview_flutter.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/assets_audio_player.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/assets_audio_player_web.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/path_provider.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/video_player.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/wakelock.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/webview_flutter.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -223,24 +253,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
-		};
-		450FC00D9CC4F56F4423DF9E /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../Flutter/Flutter.framework",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Flutter.framework",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 		8446656B443667928C090391 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -354,7 +366,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -367,6 +379,7 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = S8QB4VV633;
 				ENABLE_BITCODE = NO;
@@ -375,6 +388,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -382,6 +396,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Runner-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Profile;
@@ -433,7 +449,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -482,7 +498,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -495,6 +511,7 @@
 			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -502,6 +519,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -509,6 +527,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Debug;
@@ -518,6 +538,7 @@
 			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -525,6 +546,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -532,6 +554,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.example.example;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Release;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,6 +35,9 @@ const htmlData = """
 <h4>Header 4</h4>
 <h5>Header 5</h5>
 <h6>Header 6</h6>
+<audio controls>
+        <source src="https://www.w3schools.com/html/mov_bbb.mp4" />
+      </audio>
 <h3>Ruby Support:</h3>
       <p>
         <ruby>
@@ -128,9 +131,7 @@ const htmlData = """
         <source src="https://www.w3schools.com/html/mov_bbb.mp4" />
       </video>
       <h3>Audio support:</h3>
-      <audio controls>
-        <source src="https://www.w3schools.com/html/mov_bbb.mp4" />
-      </audio>
+     
       <h3>IFrame support:</h3>
       <iframe src="https://google.com"></iframe>
 """;

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,9 +35,6 @@ const htmlData = """
 <h4>Header 4</h4>
 <h5>Header 5</h5>
 <h6>Header 6</h6>
-<audio controls>
-        <source src="https://www.w3schools.com/html/mov_bbb.mp4" />
-      </audio>
 <h3>Ruby Support:</h3>
       <p>
         <ruby>
@@ -131,7 +128,9 @@ const htmlData = """
         <source src="https://www.w3schools.com/html/mov_bbb.mp4" />
       </video>
       <h3>Audio support:</h3>
-     
+     <audio controls>
+        <source src="https://www.w3schools.com/html/mov_bbb.mp4" />
+      </audio>
       <h3>IFrame support:</h3>
       <iframe src="https://google.com"></iframe>
 """;

--- a/lib/src/replaced_element.dart
+++ b/lib/src/replaced_element.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:chewie/chewie.dart';
-import 'package:chewie_audio/chewie_audio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -11,6 +10,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_html/html_parser.dart';
 import 'package:flutter_html/src/html_elements.dart';
 import 'package:flutter_html/src/utils.dart';
+import 'package:flutter_html/src/widgets/custom_audio_widget.dart';
 import 'package:flutter_html/style.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:html/dom.dart' as dom;
@@ -253,17 +253,7 @@ class AudioContentElement extends ReplacedElement {
   Widget toWidget(RenderContext context) {
     return Container(
       width: context.style.width ?? 300,
-      child: ChewieAudio(
-        controller: ChewieAudioController(
-          videoPlayerController: VideoPlayerController.network(
-            src.first ?? "",
-          ),
-          autoPlay: autoplay,
-          looping: loop,
-          showControls: showControls,
-          autoInitialize: true,
-        ),
-      ),
+      child: CustomAudioWidget(showControls: showControls, src: src, autoplay: autoplay, loop: loop, context: context, muted: muted)
     );
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -43,3 +43,46 @@ class MultipleTapGestureRecognizer extends TapGestureRecognizer {
     }
   }
 }
+
+String getMMSSFormat(Duration d) {
+  String twoDigits(int n) {
+    if (n >= 10) return "$n";
+    return "0$n";
+  }
+
+  String twoDigitMinutes = twoDigits(d.inMinutes.remainder(Duration.minutesPerHour));
+  String twoDigitSeconds = twoDigits(d.inSeconds.remainder(Duration.secondsPerMinute));
+  return "$twoDigitMinutes:$twoDigitSeconds";
+}
+
+String formatDuration(Duration position) {
+  final ms = position.inMilliseconds;
+
+  int seconds = ms ~/ 1000;
+  final int hours = seconds ~/ 3600;
+  seconds = seconds % 3600;
+  final minutes = seconds ~/ 60;
+  seconds = seconds % 60;
+
+  final hoursString = hours >= 10
+      ? '$hours'
+      : hours == 0
+      ? '00'
+      : '0$hours';
+
+  final minutesString = minutes >= 10
+      ? '$minutes'
+      : minutes == 0
+      ? '00'
+      : '0$minutes';
+
+  final secondsString = seconds >= 10
+      ? '$seconds'
+      : seconds == 0
+      ? '00'
+      : '0$seconds';
+
+  final formattedTime = '${hoursString == '00' ? '' : '$hoursString:'}$minutesString:$secondsString';
+
+  return formattedTime;
+}

--- a/lib/src/widgets/custom_audio_widget.dart
+++ b/lib/src/widgets/custom_audio_widget.dart
@@ -96,45 +96,49 @@ class CustomAudioWidgetState extends State<CustomAudioWidget> with SingleTickerP
                     Expanded(
                       child: Padding(
                         padding: const EdgeInsets.only(right: 20.0),
-                        child: GestureDetector(
-                          onHorizontalDragStart: (DragStartDetails details) {
-                            wasPlaying = info.isPlaying;
-                            if (info.isPlaying) {
-                              assetsAudioPlayer.pause();
-                            }
-                          },
-                          onHorizontalDragUpdate: (DragUpdateDetails details) {
-                            final box = context.findRenderObject() as RenderBox;
-                            final Offset tapPos = box.globalToLocal(details.globalPosition);
-                            final double relative = tapPos.dx / box.size.width;
-                            final Duration position = info.duration * relative;
-                            assetsAudioPlayer.seek(position);
-                          },
-                          onHorizontalDragEnd: (DragEndDetails details) {
-                            if (wasPlaying) {
-                              assetsAudioPlayer.play();
-                            }
-                          },
-                          onTapDown: (TapDownDetails details) {
-                            final box = context.findRenderObject() as RenderBox;
-                            final Offset tapPos = box.globalToLocal(details.globalPosition);
-                            final double relative = tapPos.dx / box.size.width;
-                            final Duration position = info.duration * relative;
-                            assetsAudioPlayer.seek(position);
-                          },
-                          child: Center(
-                            child: Container(
-                              height: MediaQuery.of(context).size.height / 2,
-                              width: MediaQuery.of(context).size.width,
-                              color: Colors.transparent,
-                              child: CustomPaint(
-                                painter: MaterialProgressBarPainter(
-                                  info,
-                                  ProgressColors(playedColor: Theme.of(context).primaryColor, handleColor: Theme.of(context).primaryColor),
+                        child: Builder(
+                          builder: (BuildContext progressContext) {
+                            return GestureDetector(
+                              onHorizontalDragStart: (DragStartDetails details) {
+                                wasPlaying = info.isPlaying;
+                                if (info.isPlaying) {
+                                  assetsAudioPlayer.pause();
+                                }
+                              },
+                              onHorizontalDragUpdate: (DragUpdateDetails details) {
+                                final box = progressContext.findRenderObject() as RenderBox;
+                                final Offset tapPos = box.globalToLocal(details.globalPosition);
+                                final double relative = tapPos.dx / box.size.width;
+                                final Duration position = info.duration * relative;
+                                assetsAudioPlayer.seek(position);
+                              },
+                              onHorizontalDragEnd: (DragEndDetails details) {
+                                if (wasPlaying) {
+                                  assetsAudioPlayer.play();
+                                }
+                              },
+                              onTapDown: (TapDownDetails details) {
+                                final box = progressContext.findRenderObject() as RenderBox;
+                                final Offset tapPos = box.globalToLocal(details.globalPosition);
+                                final double relative = tapPos.dx / box.size.width;
+                                final Duration position = info.duration * relative;
+                                assetsAudioPlayer.seek(position);
+                              },
+                              child: Center(
+                                child: Container(
+                                  height: MediaQuery.of(progressContext).size.height,
+                                  width: MediaQuery.of(progressContext).size.width,
+                                  color: Colors.transparent,
+                                  child: CustomPaint(
+                                    painter: MaterialProgressBarPainter(
+                                      info,
+                                      ProgressColors(playedColor: Theme.of(context).primaryColor, handleColor: Theme.of(context).primaryColor),
+                                    ),
+                                  ),
                                 ),
                               ),
-                            ),
-                          ),
+                            );
+                          },
                         ),
                       ),
                     ),
@@ -255,50 +259,54 @@ class CustomAudioWidgetState extends State<CustomAudioWidget> with SingleTickerP
                           Expanded(
                             child: Padding(
                                 padding: const EdgeInsets.only(right: 12.0),
-                                child: GestureDetector(
-                                  onHorizontalDragStart: (DragStartDetails details) {
-                                    wasPlaying = info.isPlaying;
-                                    if (info.isPlaying) {
-                                      assetsAudioPlayer.pause();
-                                    }
-                                  },
-                                  onHorizontalDragUpdate: (DragUpdateDetails details) {
-                                    final box = context.findRenderObject() as RenderBox;
-                                    final Offset tapPos = box.globalToLocal(details.globalPosition);
-                                    final double relative = tapPos.dx / box.size.width;
-                                    final Duration position = info.duration * relative;
-                                    assetsAudioPlayer.seek(position);
-                                  },
-                                  onHorizontalDragEnd: (DragEndDetails details) {
-                                    if (wasPlaying) {
-                                      assetsAudioPlayer.play();
-                                    }
-                                  },
-                                  onTapDown: (TapDownDetails details) {
-                                    final box = context.findRenderObject() as RenderBox;
-                                    final Offset tapPos = box.globalToLocal(details.globalPosition);
-                                    final double relative = tapPos.dx / box.size.width;
-                                    final Duration position = info.duration * relative;
-                                    assetsAudioPlayer.seek(position);
-                                  },
-                                  child: Center(
-                                    child: Container(
-                                      height: MediaQuery.of(context).size.height,
-                                      width: MediaQuery.of(context).size.width,
-                                      color: Colors.transparent,
-                                      child: CustomPaint(
-                                        painter: CupertinoProgressBarPainter(
-                                          info,
-                                          ProgressColors(
-                                            playedColor: const Color.fromARGB(120, 255, 255, 255,),
-                                            handleColor: const Color.fromARGB(255, 255, 255, 255,),
-                                            bufferedColor: const Color.fromARGB(60, 255, 255, 255,),
-                                            backgroundColor: const Color.fromARGB(20, 255, 255, 255,),
+                                child: Builder(
+                                  builder: (BuildContext progressContext) {
+                                    return GestureDetector(
+                                      onHorizontalDragStart: (DragStartDetails details) {
+                                        wasPlaying = info.isPlaying;
+                                        if (info.isPlaying) {
+                                          assetsAudioPlayer.pause();
+                                        }
+                                      },
+                                      onHorizontalDragUpdate: (DragUpdateDetails details) {
+                                        final box = progressContext.findRenderObject() as RenderBox;
+                                        final Offset tapPos = box.globalToLocal(details.globalPosition);
+                                        final double relative = tapPos.dx / box.size.width;
+                                        final Duration position = info.duration * relative;
+                                        assetsAudioPlayer.seek(position);
+                                      },
+                                      onHorizontalDragEnd: (DragEndDetails details) {
+                                        if (wasPlaying) {
+                                          assetsAudioPlayer.play();
+                                        }
+                                      },
+                                      onTapDown: (TapDownDetails details) {
+                                        final box = progressContext.findRenderObject() as RenderBox;
+                                        final Offset tapPos = box.globalToLocal(details.globalPosition);
+                                        final double relative = tapPos.dx / box.size.width;
+                                        final Duration position = info.duration * relative;
+                                        assetsAudioPlayer.seek(position);
+                                      },
+                                      child: Center(
+                                        child: Container(
+                                          height: MediaQuery.of(progressContext).size.height,
+                                          width: MediaQuery.of(progressContext).size.width,
+                                          color: Colors.transparent,
+                                          child: CustomPaint(
+                                            painter: CupertinoProgressBarPainter(
+                                              info,
+                                              ProgressColors(
+                                                playedColor: const Color.fromARGB(120, 255, 255, 255,),
+                                                handleColor: const Color.fromARGB(255, 255, 255, 255,),
+                                                bufferedColor: const Color.fromARGB(60, 255, 255, 255,),
+                                                backgroundColor: const Color.fromARGB(20, 255, 255, 255,),
+                                              ),
+                                            ),
                                           ),
                                         ),
                                       ),
-                                    ),
-                                  ),
+                                    );
+                                  },
                                 )
                             ),
                           ),

--- a/lib/src/widgets/custom_audio_widget.dart
+++ b/lib/src/widgets/custom_audio_widget.dart
@@ -1,0 +1,460 @@
+import 'dart:io';
+import 'dart:ui';
+
+import 'package:assets_audio_player/assets_audio_player.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_html/html_parser.dart';
+import 'package:flutter_html/src/utils.dart';
+
+class CustomAudioWidget extends StatefulWidget {
+  final List<String> src;
+  final bool showControls;
+  final bool autoplay;
+  final bool loop;
+  final bool muted;
+  final RenderContext context;
+
+  CustomAudioWidget({
+    @required this.src,
+    @required this.showControls,
+    @required this.autoplay,
+    @required this.loop,
+    @required this.muted,
+    @required this.context,
+  });
+
+  @override
+  State<StatefulWidget> createState() {
+    return CustomAudioWidgetState();
+  }
+}
+
+class CustomAudioWidgetState extends State<CustomAudioWidget> with SingleTickerProviderStateMixin {
+  final assetsAudioPlayer = AssetsAudioPlayer();
+  bool wasPlaying;
+
+  @override
+  initState() {
+    if (widget.src.first != null) {
+      assetsAudioPlayer.open(Audio.network(widget.src.first), autoStart: widget.autoplay ?? false, showNotification: true);
+      assetsAudioPlayer.setLoopMode(widget.loop == true ? LoopMode.single : LoopMode.none);
+      assetsAudioPlayer.setVolume(0.5);
+    }
+    super.initState();
+  }
+
+  @override
+  dispose() {
+    assetsAudioPlayer.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext buildContext) {
+    if (widget.src.first != null) {
+      return assetsAudioPlayer.builderRealtimePlayingInfos(
+          builder: (BuildContext context, info) {
+            if (info == null) {
+              return AspectRatio(aspectRatio: 1, child: CircularProgressIndicator());
+            } else if (Platform.isAndroid) {
+              return Container(
+                height: 48,
+                color: Theme.of(buildContext).dialogBackgroundColor,
+                child: Row(
+                  children: <Widget>[
+                    GestureDetector(
+                      onTap: () {
+                        if (info.isPlaying) {
+                          assetsAudioPlayer.pause();
+                        } else {
+                          assetsAudioPlayer.play();
+                        }
+                      },
+                      child: Container(
+                        height: 48,
+                        color: Colors.transparent,
+                        margin: const EdgeInsets.only(left: 8.0, right: 4.0),
+                        padding: const EdgeInsets.only(
+                          left: 12.0,
+                          right: 12.0,
+                        ),
+                        child: Icon(
+                          info.isPlaying ? Icons.pause : Icons.play_arrow,
+                        ),
+                      ),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(right: 24.0),
+                      child: Text(
+                        "${getMMSSFormat(info.currentPosition)} / ${getMMSSFormat(info.duration)}",
+                        style: const TextStyle(
+                          fontSize: 14.0,
+                        ),
+                      ),
+                    ),
+                    Expanded(
+                      child: Padding(
+                        padding: const EdgeInsets.only(right: 20.0),
+                        child: GestureDetector(
+                          onHorizontalDragStart: (DragStartDetails details) {
+                            wasPlaying = info.isPlaying;
+                            if (info.isPlaying) {
+                              assetsAudioPlayer.pause();
+                            }
+                          },
+                          onHorizontalDragUpdate: (DragUpdateDetails details) {
+                            final box = context.findRenderObject() as RenderBox;
+                            final Offset tapPos = box.globalToLocal(details.globalPosition);
+                            final double relative = tapPos.dx / box.size.width;
+                            final Duration position = info.duration * relative;
+                            assetsAudioPlayer.seek(position);
+                          },
+                          onHorizontalDragEnd: (DragEndDetails details) {
+                            if (wasPlaying) {
+                              assetsAudioPlayer.play();
+                            }
+                          },
+                          onTapDown: (TapDownDetails details) {
+                            final box = context.findRenderObject() as RenderBox;
+                            final Offset tapPos = box.globalToLocal(details.globalPosition);
+                            final double relative = tapPos.dx / box.size.width;
+                            final Duration position = info.duration * relative;
+                            assetsAudioPlayer.seek(position);
+                          },
+                          child: Center(
+                            child: Container(
+                              height: MediaQuery.of(context).size.height / 2,
+                              width: MediaQuery.of(context).size.width,
+                              color: Colors.transparent,
+                              child: CustomPaint(
+                                painter: MaterialProgressBarPainter(
+                                  info,
+                                  ProgressColors(playedColor: Theme.of(context).primaryColor, handleColor: Theme.of(context).primaryColor),
+                                ),
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    GestureDetector(
+                      onTap: () {
+                        if (info.volume == 0) {
+                          assetsAudioPlayer.setVolume(0.5);
+                        } else {
+                          assetsAudioPlayer.setVolume(0);
+                        }
+                      },
+                      child: ClipRect(
+                        child: Container(
+                          height: 48,
+                          padding: const EdgeInsets.only(
+                            left: 8.0,
+                            right: 8.0,
+                          ),
+                          child: Icon(
+                            info.volume == 0 ? Icons.volume_off : Icons.volume_up,
+                          ),
+                        ),
+                      ),
+                    )
+                  ],
+                ),
+              );
+            } else {
+              final barHeight = MediaQuery.of(context).orientation == Orientation.portrait ? 30.0 : 47.0;
+              double latestVolume;
+              return Container(
+                color: Colors.transparent,
+                alignment: Alignment.center,
+                margin: EdgeInsets.all(5.0),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(10.0),
+                  child: BackdropFilter(
+                    filter: ImageFilter.blur(
+                      sigmaX: 10.0,
+                      sigmaY: 10.0,
+                    ),
+                    child: Container(
+                      height: barHeight,
+                      color: Color.fromRGBO(41, 41, 41, 0.7),
+                      child: Row(
+                        children: <Widget>[
+                          GestureDetector(
+                            onTap: () {
+                              assetsAudioPlayer.seekBy(Duration(seconds: -15));
+                            },
+                            child: Container(
+                              height: barHeight,
+                              color: Colors.transparent,
+                              margin: const EdgeInsets.only(left: 10.0),
+                              padding: const EdgeInsets.only(
+                                left: 6.0,
+                                right: 6.0,
+                              ),
+                              child: Icon(
+                                CupertinoIcons.gobackward_15,
+                                color: Color.fromARGB(255, 200, 200, 200),
+                                size: 18.0,
+                              ),
+                            ),
+                          ),
+                          GestureDetector(
+                            onTap: () {
+                              if (info.isPlaying) {
+                                assetsAudioPlayer.pause();
+                              } else {
+                                assetsAudioPlayer.play();
+                              }
+                            },
+                            child: Container(
+                              height: barHeight,
+                              color: Colors.transparent,
+                              padding: const EdgeInsets.only(
+                                left: 6.0,
+                                right: 6.0,
+                              ),
+                              child: Icon(
+                                info.isPlaying ? Icons.pause : Icons.play_arrow,
+                                color: Color.fromARGB(255, 200, 200, 200),
+                              ),
+                            ),
+                          ),
+                          GestureDetector(
+                            onTap: () {
+                              assetsAudioPlayer.seekBy(Duration(seconds: 15));
+                            },
+                            child: Container(
+                              height: barHeight,
+                              color: Colors.transparent,
+                              padding: const EdgeInsets.only(
+                                left: 6.0,
+                                right: 8.0,
+                              ),
+                              margin: const EdgeInsets.only(
+                                right: 8.0,
+                              ),
+                              child: Icon(
+                                CupertinoIcons.goforward_15,
+                                color: Color.fromARGB(255, 200, 200, 200),
+                                size: 18.0,
+                              ),
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.only(right: 12.0),
+                            child: Text(
+                              formatDuration(info.currentPosition),
+                              style: TextStyle(
+                                color: Color.fromARGB(255, 200, 200, 200),
+                                fontSize: 12.0,
+                              ),
+                            ),
+                          ),
+                          Expanded(
+                            child: Padding(
+                                padding: const EdgeInsets.only(right: 12.0),
+                                child: GestureDetector(
+                                  onHorizontalDragStart: (DragStartDetails details) {
+                                    wasPlaying = info.isPlaying;
+                                    if (info.isPlaying) {
+                                      assetsAudioPlayer.pause();
+                                    }
+                                  },
+                                  onHorizontalDragUpdate: (DragUpdateDetails details) {
+                                    final box = context.findRenderObject() as RenderBox;
+                                    final Offset tapPos = box.globalToLocal(details.globalPosition);
+                                    final double relative = tapPos.dx / box.size.width;
+                                    final Duration position = info.duration * relative;
+                                    assetsAudioPlayer.seek(position);
+                                  },
+                                  onHorizontalDragEnd: (DragEndDetails details) {
+                                    if (wasPlaying) {
+                                      assetsAudioPlayer.play();
+                                    }
+                                  },
+                                  onTapDown: (TapDownDetails details) {
+                                    final box = context.findRenderObject() as RenderBox;
+                                    final Offset tapPos = box.globalToLocal(details.globalPosition);
+                                    final double relative = tapPos.dx / box.size.width;
+                                    final Duration position = info.duration * relative;
+                                    assetsAudioPlayer.seek(position);
+                                  },
+                                  child: Center(
+                                    child: Container(
+                                      height: MediaQuery.of(context).size.height,
+                                      width: MediaQuery.of(context).size.width,
+                                      color: Colors.transparent,
+                                      child: CustomPaint(
+                                        painter: CupertinoProgressBarPainter(
+                                          info,
+                                          ProgressColors(
+                                            playedColor: const Color.fromARGB(120, 255, 255, 255,),
+                                            handleColor: const Color.fromARGB(255, 255, 255, 255,),
+                                            bufferedColor: const Color.fromARGB(60, 255, 255, 255,),
+                                            backgroundColor: const Color.fromARGB(20, 255, 255, 255,),
+                                          ),
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                )
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.only(right: 12.0),
+                            child: Text(
+                              '-${formatDuration(info.duration - info.currentPosition)}',
+                              style: TextStyle(color: Color.fromARGB(255, 200, 200, 200), fontSize: 12.0),
+                            ),
+                          ),
+                          Padding(
+                            padding: const EdgeInsets.only(right: 12),
+                            child: GestureDetector(
+                              onTap: () {
+                                if (info.volume == 0) {
+                                  assetsAudioPlayer.setVolume(latestVolume ?? 0.5);
+                                } else {
+                                  latestVolume = info.volume;
+                                  assetsAudioPlayer.setVolume(0.0);
+                                }
+                              },
+                              child: SizedBox(
+                                height: barHeight,
+                                child: Icon(
+                                  info.volume > 0 ? Icons.volume_up : Icons.volume_off,
+                                  color: Color.fromARGB(255, 200, 200, 200),
+                                  size: 16.0,
+                                ),
+                              ),
+                            ),
+                          )
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+              );
+            }
+          }
+      );
+    } else {
+      return Container(height: 0, width: 0);
+    }
+  }
+}
+
+class MaterialProgressBarPainter extends CustomPainter {
+  MaterialProgressBarPainter(this.info, this.colors);
+
+  RealtimePlayingInfos info;
+  ProgressColors colors;
+
+  @override
+  bool shouldRepaint(CustomPainter painter) {
+    return true;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const height = 2.0;
+
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromPoints(
+          Offset(0.0, size.height / 2),
+          Offset(size.width, size.height / 2 + height),
+        ),
+        const Radius.circular(4.0),
+      ),
+      colors.backgroundPaint,
+    );
+    final double playedPartPercent = info.duration.inMilliseconds == 0 ? 0 : info.currentPosition.inMilliseconds / info.duration.inMilliseconds;
+    final double playedPart = playedPartPercent >= 1 ? size.width : playedPartPercent * size.width;
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromPoints(
+          Offset(0.0, size.height / 2),
+          Offset(playedPart, size.height / 2 + height),
+        ),
+        const Radius.circular(4.0),
+      ),
+      colors.playedPaint,
+    );
+    canvas.drawCircle(
+      Offset(playedPart, size.height / 2 + height / 2),
+      height * 3,
+      colors.handlePaint,
+    );
+  }
+}
+
+class CupertinoProgressBarPainter extends CustomPainter {
+  CupertinoProgressBarPainter(this.info, this.colors);
+
+  RealtimePlayingInfos info;
+  ProgressColors colors;
+
+  @override
+  bool shouldRepaint(CustomPainter painter) {
+    return true;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    const barHeight = 5.0;
+    const handleHeight = 6.0;
+    final baseOffset = size.height / 2 - barHeight / 2.0;
+
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromPoints(
+          Offset(0.0, baseOffset),
+          Offset(size.width, baseOffset + barHeight),
+        ),
+        const Radius.circular(4.0),
+      ),
+      colors.backgroundPaint,
+    );
+    final double playedPartPercent = info.duration.inMilliseconds == 0 ? 0 : info.currentPosition.inMilliseconds / info.duration.inMilliseconds;
+    final double playedPart = playedPartPercent > 1 ? size.width : playedPartPercent * size.width;
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromPoints(
+          Offset(0.0, baseOffset),
+          Offset(playedPart, baseOffset + barHeight),
+        ),
+        const Radius.circular(4.0),
+      ),
+      colors.playedPaint,
+    );
+
+    final shadowPath = Path()
+      ..addOval(Rect.fromCircle(center: Offset(playedPart, baseOffset + barHeight / 2), radius: handleHeight));
+
+    canvas.drawShadow(shadowPath, Colors.black, 0.2, false);
+    canvas.drawCircle(
+      Offset(playedPart, baseOffset + barHeight / 2),
+      handleHeight,
+      colors.handlePaint,
+    );
+  }
+}
+
+class ProgressColors {
+  ProgressColors({
+    Color playedColor = const Color.fromRGBO(255, 0, 0, 0.7),
+    Color bufferedColor = const Color.fromRGBO(30, 30, 200, 0.2),
+    Color handleColor = const Color.fromRGBO(200, 200, 200, 1.0),
+    Color backgroundColor = const Color.fromRGBO(200, 200, 200, 0.5),
+  })  : playedPaint = Paint()..color = playedColor,
+        bufferedPaint = Paint()..color = bufferedColor,
+        handlePaint = Paint()..color = handleColor,
+        backgroundPaint = Paint()..color = backgroundColor;
+
+  final Paint playedPaint;
+  final Paint bufferedPaint;
+  final Paint handlePaint;
+  final Paint backgroundPaint;
+}

--- a/lib/src/widgets/custom_audio_widget.dart
+++ b/lib/src/widgets/custom_audio_widget.dart
@@ -194,7 +194,7 @@ class CustomAudioWidgetState extends State<CustomAudioWidget> with SingleTickerP
                                 right: 6.0,
                               ),
                               child: Icon(
-                                CupertinoIcons.gobackward_15,
+                                CupertinoIcons.gobackward_10,
                                 color: Color.fromARGB(255, 200, 200, 200),
                                 size: 18.0,
                               ),
@@ -236,7 +236,7 @@ class CustomAudioWidgetState extends State<CustomAudioWidget> with SingleTickerP
                                 right: 8.0,
                               ),
                               child: Icon(
-                                CupertinoIcons.goforward_15,
+                                CupertinoIcons.goforward_10,
                                 color: Color.fromARGB(255, 200, 200, 200),
                                 size: 18.0,
                               ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   webview_flutter: ^1.0.0
 
   # Plugins for rendering the <audio> tag.
-  chewie_audio: ^1.1.1
+  assets_audio_player: ^2.0.13+1
 
   # Plugins for rendering the <svg> tag.
   flutter_svg: ^0.19.0


### PR DESCRIPTION
Fixes #399 

BREAKING updates minimum deploment target to iOS 9.0 - however this should not be a huge deal since Flutter officially dropped support for iOS 8.0 (see [here](https://github.com/flutter/flutter/pull/62902))

I borrowed the UI from chewie so that we would keep the Material/Cupertino style audio player, but with this implementation the errors on iOS should be gone now. This implementation would also allow us to potentially load audio from local files as well, if this is a feature we think should be added.

I don't have a physical iOS device but I tested on a Simulator and scrubbing through the progressbar felt a bit janky, if someone could test on a physical device and report their experience that would be great! Edit: I think I fixed the janky behavior in the last commit, but feedback is welcome still. 