### PR TITLE
Minor fix to prevent rendering exception when video and audio sources don't exist

### DIFF
--- a/lib/src/replaced_element.dart
+++ b/lib/src/replaced_element.dart
@@ -409,11 +409,7 @@ ReplacedElement parseReplacedElement(
         if (element.attributes['src'] != null) element.attributes['src'],
         ...ReplacedElement.parseMediaSources(element.children),
       ];
-      bool matchFound = false;
-      for (String s in sources) {
-        matchFound = s == null ? false : RegExp(r"^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?))\://)?(www.|[a-zA-Z0-9].)[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,6}(\:[0-9]{1,5})*(/($|[a-zA-Z0-9\.\,\;\?\'\\\+&amp;%\$#\=~_\-]+))*$").hasMatch(s);
-      }
-      if (sources == null || sources.isEmpty || !matchFound) {
+      if (sources == null || sources.isEmpty || sources.first == null) {
         return EmptyContentElement();
       }
       return AudioContentElement(
@@ -450,11 +446,7 @@ ReplacedElement parseReplacedElement(
         if (element.attributes['src'] != null) element.attributes['src'],
         ...ReplacedElement.parseMediaSources(element.children),
       ];
-      bool matchFound = false;
-      for (String s in sources) {
-        matchFound = s == null ? false : RegExp(r"^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?))\://)?(www.|[a-zA-Z0-9].)[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,6}(\:[0-9]{1,5})*(/($|[a-zA-Z0-9\.\,\;\?\'\\\+&amp;%\$#\=~_\-]+))*$").hasMatch(s);
-      }
-      if (sources == null || sources.isEmpty || !matchFound) {
+      if (sources == null || sources.isEmpty || sources.first == null) {
         return EmptyContentElement();
       }
       return VideoContentElement(

--- a/lib/src/replaced_element.dart
+++ b/lib/src/replaced_element.dart
@@ -409,7 +409,11 @@ ReplacedElement parseReplacedElement(
         if (element.attributes['src'] != null) element.attributes['src'],
         ...ReplacedElement.parseMediaSources(element.children),
       ];
-      if (sources == null || sources.isEmpty) {
+      bool matchFound = false;
+      for (String s in sources) {
+        matchFound = s == null ? false : RegExp(r"^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?))\://)?(www.|[a-zA-Z0-9].)[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,6}(\:[0-9]{1,5})*(/($|[a-zA-Z0-9\.\,\;\?\'\\\+&amp;%\$#\=~_\-]+))*$").hasMatch(s);
+      }
+      if (sources == null || sources.isEmpty || !matchFound) {
         return EmptyContentElement();
       }
       return AudioContentElement(
@@ -446,7 +450,11 @@ ReplacedElement parseReplacedElement(
         if (element.attributes['src'] != null) element.attributes['src'],
         ...ReplacedElement.parseMediaSources(element.children),
       ];
-      if (sources == null || sources.isEmpty) {
+      bool matchFound = false;
+      for (String s in sources) {
+        matchFound = s == null ? false : RegExp(r"^((((H|h)(T|t)|(F|f))(T|t)(P|p)((S|s)?))\://)?(www.|[a-zA-Z0-9].)[a-zA-Z0-9\-\.]+\.[a-zA-Z]{2,6}(\:[0-9]{1,5})*(/($|[a-zA-Z0-9\.\,\;\?\'\\\+&amp;%\$#\=~_\-]+))*$").hasMatch(s);
+      }
+      if (sources == null || sources.isEmpty || !matchFound) {
         return EmptyContentElement();
       }
       return VideoContentElement(

--- a/lib/src/replaced_element.dart
+++ b/lib/src/replaced_element.dart
@@ -409,6 +409,9 @@ ReplacedElement parseReplacedElement(
         if (element.attributes['src'] != null) element.attributes['src'],
         ...ReplacedElement.parseMediaSources(element.children),
       ];
+      if (sources == null || sources.isEmpty) {
+        return EmptyContentElement();
+      }
       return AudioContentElement(
         name: "audio",
         src: sources,
@@ -443,6 +446,9 @@ ReplacedElement parseReplacedElement(
         if (element.attributes['src'] != null) element.attributes['src'],
         ...ReplacedElement.parseMediaSources(element.children),
       ];
+      if (sources == null || sources.isEmpty) {
+        return EmptyContentElement();
+      }
       return VideoContentElement(
         name: "video",
         src: sources,


### PR DESCRIPTION
Fixes #518. Sample HTML:
```
<div>
<video>
</video>
</div>
```