### PR TITLE
Add support for various inline styles

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -683,7 +683,7 @@ class HtmlParser extends StatelessWidget {
     tree.children?.forEach((child) {
       if ((child.style.fontSize?.size ?? parentFontSize) < 0) {
         child.style.fontSize =
-            FontSize(parentFontSize * -child.style.fontSize.size);
+            FontSize(parentFontSize * -child.style.fontSize.size, "");
       }
 
       _processFontSize(child);

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -685,7 +685,7 @@ class HtmlParser extends StatelessWidget {
     tree.children?.forEach((child) {
       if ((child.style.fontSize?.size ?? parentFontSize) < 0) {
         child.style.fontSize =
-            FontSize(parentFontSize * -child.style.fontSize.size, "");
+            FontSize(parentFontSize * -child.style.fontSize.size);
       }
 
       _processFontSize(child);

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -661,6 +661,8 @@ class HtmlParser extends StatelessWidget {
           child.text.trim().isEmpty &&
           lastChildBlock) {
         toRemove.add(child);
+      } else if (child.style.display == Display.NONE) {
+        toRemove.add(child);
       } else {
         _removeEmptyElements(child);
       }

--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -78,9 +78,9 @@ class ExpressionMapping {
     } else if (value is css.PercentageTerm) {
       return FontSize.percent(int.tryParse(value.text.replaceAll(new RegExp(r'[^0-9]'),'')));
     } else if (value is css.EmTerm) {
-      return FontSize(double.tryParse(value.text.replaceAll(new RegExp(r'[^0-9]'), '')));
+      return FontSize.em(int.tryParse(value.text.replaceAll(new RegExp(r'[^0-9]'), '')));
     } else if (value is css.RemTerm) {
-      return FontSize(double.tryParse(value.text.replaceAll(new RegExp(r'[^0-9]'), '')));
+      return FontSize.em(int.tryParse(value.text.replaceAll(new RegExp(r'[^0-9]'), '')));
     } else if (value is css.LiteralTerm) {
       switch (value.text) {
         case "xx-small":

--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -9,17 +9,31 @@ Style declarationsToStyle(Map<String, List<css.Expression>> declarations) {
   declarations.forEach((property, value) {
     switch (property) {
       case 'background-color':
-        style.backgroundColor =
-            ExpressionMapping.expressionToColor(value.first);
+        style.backgroundColor = ExpressionMapping.expressionToColor(value.first);
         break;
       case 'color':
         style.color = ExpressionMapping.expressionToColor(value.first);
         break;
-      case 'text-align':
-        style.textAlign = ExpressionMapping.expressionToTextAlign(value.first);
+      case 'direction':
+        style.direction = ExpressionMapping.expressionToDirection(value.first);
+        break;
+      case 'display':
+        style.display = ExpressionMapping.expressionToDisplay(value.first);
+        break;
+      case 'font-family':
+        style.fontFamily = ExpressionMapping.expressionToFontFamily(value.first);
         break;
       case 'font-size':
         style.fontSize = ExpressionMapping.expressionToFontSize(value.first);
+        break;
+      case 'font-style':
+        style.fontStyle = ExpressionMapping.expressionToFontStyle(value.first);
+        break;
+      case 'font-weight':
+        style.fontWeight = ExpressionMapping.expressionToFontWeight(value.first);
+        break;
+      case 'text-align':
+        style.textAlign = ExpressionMapping.expressionToTextAlign(value.first);
         break;
     }
   });
@@ -72,6 +86,36 @@ class ExpressionMapping {
     return null;
   }
 
+  static TextDirection expressionToDirection(css.Expression value) {
+    if (value is css.LiteralTerm) {
+      switch(value.text) {
+        case "ltr":
+          return TextDirection.ltr;
+        case "rtl":
+          return TextDirection.rtl;
+      }
+    }
+    return TextDirection.ltr;
+  }
+
+  static Display expressionToDisplay(css.Expression value) {
+    if (value is css.LiteralTerm) {
+      switch(value.text) {
+        case 'block':
+          return Display.BLOCK;
+        case 'inline-block':
+          return Display.INLINE_BLOCK;
+        case 'inline':
+          return Display.INLINE;
+        case 'list-item':
+          return Display.LIST_ITEM;
+        case 'none':
+          return Display.NONE;
+      }
+    }
+    return Display.INLINE;
+  }
+
   static FontSize expressionToFontSize(css.Expression value) {
     if (value is css.NumberTerm) {
       return FontSize(double.tryParse(value.text), "");
@@ -100,6 +144,59 @@ class ExpressionMapping {
       }
       return FontSize(double.tryParse(value.text.replaceAll(new RegExp(r'\s+(\d+\.\d+)\s+'), '')), "");
     }
+    return null;
+  }
+
+  static FontStyle expressionToFontStyle(css.Expression value) {
+    if (value is css.LiteralTerm) {
+      switch(value.text) {
+        case "italic":
+        case "oblique":
+          return FontStyle.italic;
+      }
+      return FontStyle.normal;
+    }
+    return FontStyle.normal;
+  }
+
+  static FontWeight expressionToFontWeight(css.Expression value) {
+    if (value is css.NumberTerm) {
+      switch (value.text) {
+        case "100":
+          return FontWeight.w100;
+        case "200":
+          return FontWeight.w200;
+        case "300":
+          return FontWeight.w300;
+        case "400":
+          return FontWeight.w400;
+        case "500":
+          return FontWeight.w500;
+        case "600":
+          return FontWeight.w600;
+        case "700":
+          return FontWeight.w700;
+        case "800":
+          return FontWeight.w800;
+        case "900":
+          return FontWeight.w900;
+      }
+    } else if (value is css.LiteralTerm) {
+      switch(value.text) {
+        case "bold":
+          return FontWeight.bold;
+        case "bolder":
+          return FontWeight.w900;
+        case "lighter":
+          return FontWeight.w200;
+      }
+      return FontWeight.normal;
+    }
+    return FontWeight.normal;
+  }
+
+  static String expressionToFontFamily(css.Expression value) {
+    if (value is css.LiteralTerm) return value.text;
     return null;
   }
 

--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -18,7 +18,9 @@ Style declarationsToStyle(Map<String, List<css.Expression>> declarations) {
       case 'text-align':
         style.textAlign = ExpressionMapping.expressionToTextAlign(value.first);
         break;
-
+      case 'font-size':
+        style.fontSize = ExpressionMapping.expressionToFontSize(value.first);
+        break;
     }
   });
   return style;
@@ -66,6 +68,37 @@ class ExpressionMapping {
       } else if (value.text == 'rgb') {
         return rgbOrRgbaToColor(value.span.text);
       }
+    }
+    return null;
+  }
+
+  static FontSize expressionToFontSize(css.Expression value) {
+    if (value is css.NumberTerm) {
+      return FontSize(double.tryParse(value.text));
+    } else if (value is css.PercentageTerm) {
+      return FontSize.percent(int.tryParse(value.text.replaceAll(new RegExp(r'[^0-9]'),'')));
+    } else if (value is css.EmTerm) {
+      return FontSize(double.tryParse(value.text.replaceAll(new RegExp(r'[^0-9]'), '')));
+    } else if (value is css.RemTerm) {
+      return FontSize(double.tryParse(value.text.replaceAll(new RegExp(r'[^0-9]'), '')));
+    } else if (value is css.LiteralTerm) {
+      switch (value.text) {
+        case "xx-small":
+          return FontSize.xxSmall;
+        case "x-small":
+          return FontSize.xSmall;
+        case "small":
+          return FontSize.small;
+        case "medium":
+          return FontSize.medium;
+        case "large":
+          return FontSize.large;
+        case "x-large":
+          return FontSize.xLarge;
+        case "xx-large":
+          return FontSize.xxLarge;
+      }
+      return FontSize(double.tryParse(value.text.replaceAll(new RegExp(r'[^0-9]'), '')));
     }
     return null;
   }

--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -23,6 +23,9 @@ Style declarationsToStyle(Map<String, List<css.Expression>> declarations) {
       case 'font-family':
         style.fontFamily = ExpressionMapping.expressionToFontFamily(value.first);
         break;
+      case 'font-feature-settings':
+        style.fontFeatureSettings = ExpressionMapping.expressionToFontFeatureSettings(value);
+        break;
       case 'font-size':
         style.fontSize = ExpressionMapping.expressionToFontSize(value.first);
         break;
@@ -114,6 +117,29 @@ class ExpressionMapping {
       }
     }
     return Display.INLINE;
+  }
+
+  static List<FontFeature> expressionToFontFeatureSettings(List<css.Expression> value) {
+    List<FontFeature> fontFeatures = [];
+    for (int i = 0; i < value.length; i++) {
+      css.Expression exp = value[i];
+      if (exp is css.LiteralTerm) {
+        if (exp.text != "on" && exp.text != "off" && exp.text != "1" && exp.text != "0") {
+          if (i < value.length - 1) {
+            css.Expression nextExp = value[i+1];
+            if (nextExp is css.LiteralTerm && (nextExp.text == "on" || nextExp.text == "off" || nextExp.text == "1" || nextExp.text == "0")) {
+              fontFeatures.add(FontFeature(exp.text, nextExp.text == "on" || nextExp.text == "1" ? 1 : 0));
+            } else {
+              fontFeatures.add(FontFeature.enable(exp.text));
+            }
+          } else {
+            fontFeatures.add(FontFeature.enable(exp.text));
+          }
+        }
+      }
+    }
+    fontFeatures.toSet().toList();
+    return fontFeatures;
   }
 
   static FontSize expressionToFontSize(css.Expression value) {

--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -74,13 +74,13 @@ class ExpressionMapping {
 
   static FontSize expressionToFontSize(css.Expression value) {
     if (value is css.NumberTerm) {
-      return FontSize(double.tryParse(value.text));
+      return FontSize(double.tryParse(value.text), "");
     } else if (value is css.PercentageTerm) {
-      return FontSize.percent(int.tryParse(value.text.replaceAll(new RegExp(r'[^0-9]'),'')));
+      return FontSize.percent(int.tryParse(value.text));
     } else if (value is css.EmTerm) {
-      return FontSize.em(int.tryParse(value.text.replaceAll(new RegExp(r'[^0-9]'), '')));
+      return FontSize.em(double.tryParse(value.text));
     } else if (value is css.RemTerm) {
-      return FontSize.em(int.tryParse(value.text.replaceAll(new RegExp(r'[^0-9]'), '')));
+      return FontSize.rem(double.tryParse(value.text));
     } else if (value is css.LiteralTerm) {
       switch (value.text) {
         case "xx-small":
@@ -98,7 +98,7 @@ class ExpressionMapping {
         case "xx-large":
           return FontSize.xxLarge;
       }
-      return FontSize(double.tryParse(value.text.replaceAll(new RegExp(r'[^0-9]'), '')));
+      return FontSize(double.tryParse(value.text.replaceAll(new RegExp(r'\s+(\d+\.\d+)\s+'), '')), "");
     }
     return null;
   }

--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -42,15 +42,17 @@ Style declarationsToStyle(Map<String, List<css.Expression>> declarations) {
         style.textAlign = ExpressionMapping.expressionToTextAlign(value.first);
         break;
       case 'text-decoration':
-        List<css.LiteralTerm> exp1  = value.whereType<css.LiteralTerm>().toList();
-        exp1.removeWhere((element) => element.text != "overline" && element.text != "underline" && element.text != "line-through");
-        css.Expression exp2 = value.firstWhere((element) => element is css.HexColorTerm || element is css.FunctionTerm, orElse: null);
+        List<css.LiteralTerm> textDecorationList  = value.whereType<css.LiteralTerm>().toList();
+        /// List<css.LiteralTerm> might include other values than the ones we want for [textDecorationList], so make sure to remove those before passing it to [ExpressionMapping]
+        textDecorationList.removeWhere((element) => element.text != "overline" && element.text != "underline" && element.text != "line-through");
+        css.Expression textDecorationColor = value.firstWhere((element) => element is css.HexColorTerm || element is css.FunctionTerm, orElse: null);
         List<css.LiteralTerm> temp = value.whereType<css.LiteralTerm>().toList();
-        temp.removeWhere((element) => element is css.HexColorTerm || element is css.FunctionTerm);
-        css.LiteralTerm exp3 = temp.last ?? null;
-        style.textDecoration = ExpressionMapping.expressionToTextDecorationLine(exp1);
-        if (exp2 != null) style.textDecorationColor = ExpressionMapping.expressionToColor(exp2);
-        if (exp3 != null) style.textDecorationStyle = ExpressionMapping.expressionToTextDecorationStyle(exp3);
+        /// List<css.LiteralTerm> might include other values than the ones we want for [textDecorationStyle], so make sure to remove those before passing it to [ExpressionMapping]
+        temp.removeWhere((element) => element.text != "solid" && element.text != "double" && element.text != "dashed" && element.text != "dotted" && element.text != "wavy");
+        css.LiteralTerm textDecorationStyle = temp.last ?? null;
+        style.textDecoration = ExpressionMapping.expressionToTextDecorationLine(textDecorationList);
+        if (textDecorationColor != null) style.textDecorationColor = ExpressionMapping.expressionToColor(textDecorationColor);
+        if (textDecorationStyle != null) style.textDecorationStyle = ExpressionMapping.expressionToTextDecorationStyle(textDecorationStyle);
         break;
       case 'text-decoration-color':
         style.textDecorationColor = ExpressionMapping.expressionToColor(value.first);
@@ -170,7 +172,7 @@ class ExpressionMapping {
 
   static FontSize expressionToFontSize(css.Expression value) {
     if (value is css.NumberTerm) {
-      return FontSize(double.tryParse(value.text), "");
+      return FontSize(double.tryParse(value.text));
     } else if (value is css.PercentageTerm) {
       return FontSize.percent(int.tryParse(value.text));
     } else if (value is css.EmTerm) {
@@ -178,7 +180,7 @@ class ExpressionMapping {
     } else if (value is css.RemTerm) {
       return FontSize.rem(double.tryParse(value.text));
     } else if (value is css.LengthTerm) {
-      return FontSize(double.tryParse(value.text.replaceAll(new RegExp(r'\s+(\d+\.\d+)\s+'), '')), "");
+      return FontSize(double.tryParse(value.text.replaceAll(new RegExp(r'\s+(\d+\.\d+)\s+'), '')));
     } else if (value is css.LiteralTerm) {
       switch (value.text) {
         case "xx-small":
@@ -263,7 +265,7 @@ class ExpressionMapping {
     } else if (value is css.RemTerm) {
       return LineHeight.rem(double.tryParse(value.text));
     } else if (value is css.LengthTerm) {
-      return LineHeight(double.tryParse(value.text.replaceAll(new RegExp(r'\s+(\d+\.\d+)\s+'), '')), "length");
+      return LineHeight(double.tryParse(value.text.replaceAll(new RegExp(r'\s+(\d+\.\d+)\s+'), '')), units: "length");
     }
     return LineHeight.normal;
   }

--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:csslib/visitor.dart' as css;
 import 'package:csslib/parser.dart' as cssparser;
+import 'package:flutter/cupertino.dart';
 import 'package:flutter_html/style.dart';
 
 Style declarationsToStyle(Map<String, List<css.Expression>> declarations) {
@@ -44,7 +45,7 @@ Style declarationsToStyle(Map<String, List<css.Expression>> declarations) {
       case 'text-decoration':
         List<css.LiteralTerm> textDecorationList  = value.whereType<css.LiteralTerm>().toList();
         /// List<css.LiteralTerm> might include other values than the ones we want for [textDecorationList], so make sure to remove those before passing it to [ExpressionMapping]
-        textDecorationList.removeWhere((element) => element.text != "overline" && element.text != "underline" && element.text != "line-through");
+        textDecorationList.removeWhere((element) => element.text != "none" && element.text != "overline" && element.text != "underline" && element.text != "line-through");
         css.Expression textDecorationColor = value.firstWhere((element) => element is css.HexColorTerm || element is css.FunctionTerm, orElse: null);
         List<css.LiteralTerm> temp = value.whereType<css.LiteralTerm>().toList();
         /// List<css.LiteralTerm> might include other values than the ones we want for [textDecorationStyle], so make sure to remove those before passing it to [ExpressionMapping]
@@ -166,8 +167,8 @@ class ExpressionMapping {
         }
       }
     }
-    fontFeatures.toSet().toList();
-    return fontFeatures;
+    List<FontFeature> finalFontFeatures = fontFeatures.toSet().toList();
+    return finalFontFeatures;
   }
 
   static FontSize expressionToFontSize(css.Expression value) {
@@ -308,6 +309,7 @@ class ExpressionMapping {
           break;
       }
     }
+    if (decorationList.contains(TextDecoration.none)) decorationList = [TextDecoration.none];
     return TextDecoration.combine(decorationList);
   }
 
@@ -373,8 +375,8 @@ class ExpressionMapping {
         }
       }
     }
-    shadow.toSet().toList();
-    return shadow;
+    List<Shadow> finalShadows = shadow.toSet().toList();
+    return finalShadows;
   }
 
   static Color stringToColor(String _text) {

--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -41,6 +41,26 @@ Style declarationsToStyle(Map<String, List<css.Expression>> declarations) {
       case 'text-align':
         style.textAlign = ExpressionMapping.expressionToTextAlign(value.first);
         break;
+      case 'text-decoration':
+        List<css.LiteralTerm> exp1  = value.whereType<css.LiteralTerm>().toList();
+        exp1.removeWhere((element) => element.text != "overline" && element.text != "underline" && element.text != "line-through");
+        css.Expression exp2 = value.firstWhere((element) => element is css.HexColorTerm || element is css.FunctionTerm, orElse: null);
+        List<css.LiteralTerm> temp = value.whereType<css.LiteralTerm>().toList();
+        temp.removeWhere((element) => element is css.HexColorTerm || element is css.FunctionTerm);
+        css.LiteralTerm exp3 = temp.last ?? null;
+        style.textDecoration = ExpressionMapping.expressionToTextDecorationLine(exp1);
+        if (exp2 != null) style.textDecorationColor = ExpressionMapping.expressionToColor(exp2);
+        if (exp3 != null) style.textDecorationStyle = ExpressionMapping.expressionToTextDecorationStyle(exp3);
+        break;
+      case 'text-decoration-color':
+        style.textDecorationColor = ExpressionMapping.expressionToColor(value.first);
+        break;
+      case 'text-decoration-line':
+        style.textDecoration = ExpressionMapping.expressionToTextDecorationLine(value);
+        break;
+      case 'text-decoration-style':
+        style.textDecorationStyle = ExpressionMapping.expressionToTextDecorationStyle(value.first);
+        break;
       case 'text-shadow':
         style.textShadow = ExpressionMapping.expressionToTextShadow(value);
         break;
@@ -266,6 +286,42 @@ class ExpressionMapping {
       }
     }
     return TextAlign.start;
+  }
+
+  static TextDecoration expressionToTextDecorationLine(List<css.LiteralTerm> value) {
+    List<TextDecoration> decorationList = [];
+    for (css.LiteralTerm term in value) {
+      switch(term.text) {
+        case "overline":
+          decorationList.add(TextDecoration.overline);
+          break;
+        case "underline":
+          decorationList.add(TextDecoration.underline);
+          break;
+        case "line-through":
+          decorationList.add(TextDecoration.lineThrough);
+          break;
+        default:
+          decorationList.add(TextDecoration.none);
+          break;
+      }
+    }
+    return TextDecoration.combine(decorationList);
+  }
+
+  static TextDecorationStyle expressionToTextDecorationStyle(css.LiteralTerm value) {
+    switch(value.text) {
+      case "wavy":
+        return TextDecorationStyle.wavy;
+      case "dotted":
+        return TextDecorationStyle.dotted;
+      case "dashed":
+        return TextDecorationStyle.dashed;
+      case "double":
+        return TextDecorationStyle.double;
+      default:
+        return TextDecorationStyle.solid;
+    }
   }
 
   static List<Shadow> expressionToTextShadow(List<css.Expression> value) {

--- a/lib/src/styled_element.dart
+++ b/lib/src/styled_element.dart
@@ -196,7 +196,7 @@ StyledElement parseStyledElement(
       break;
     case "h3":
       styledElement.style = Style(
-        fontSize: FontSize(16.38, ""),
+        fontSize: FontSize(16.38),
         fontWeight: FontWeight.bold,
         margin: EdgeInsets.symmetric(vertical: 16.5),
         display: Display.BLOCK,
@@ -212,7 +212,7 @@ StyledElement parseStyledElement(
       break;
     case "h5":
       styledElement.style = Style(
-        fontSize: FontSize(11.62, ""),
+        fontSize: FontSize(11.62),
         fontWeight: FontWeight.bold,
         margin: EdgeInsets.symmetric(vertical: 19.25),
         display: Display.BLOCK,
@@ -220,7 +220,7 @@ StyledElement parseStyledElement(
       break;
     case "h6":
       styledElement.style = Style(
-        fontSize: FontSize(9.38, ""),
+        fontSize: FontSize(9.38),
         fontWeight: FontWeight.bold,
         margin: EdgeInsets.symmetric(vertical: 22),
         display: Display.BLOCK,

--- a/lib/src/styled_element.dart
+++ b/lib/src/styled_element.dart
@@ -196,7 +196,7 @@ StyledElement parseStyledElement(
       break;
     case "h3":
       styledElement.style = Style(
-        fontSize: FontSize(16.38),
+        fontSize: FontSize(16.38, ""),
         fontWeight: FontWeight.bold,
         margin: EdgeInsets.symmetric(vertical: 16.5),
         display: Display.BLOCK,
@@ -212,7 +212,7 @@ StyledElement parseStyledElement(
       break;
     case "h5":
       styledElement.style = Style(
-        fontSize: FontSize(11.62),
+        fontSize: FontSize(11.62, ""),
         fontWeight: FontWeight.bold,
         margin: EdgeInsets.symmetric(vertical: 19.25),
         display: Display.BLOCK,
@@ -220,7 +220,7 @@ StyledElement parseStyledElement(
       break;
     case "h6":
       styledElement.style = Style(
-        fontSize: FontSize(9.38),
+        fontSize: FontSize(9.38, ""),
         fontWeight: FontWeight.bold,
         margin: EdgeInsets.symmetric(vertical: 22),
         display: Display.BLOCK,

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -409,6 +409,9 @@ class FontSize {
     return FontSize(percent.toDouble() / -100.0);
   }
 
+  factory FontSize.em(int em) {
+    return FontSize(em.toDouble() * 16 - 2);
+  }
   // These values are calculated based off of the default (`medium`)
   // being 14px.
   //

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -166,7 +166,7 @@ class Style {
   ///
   /// Inherited: no,
   /// Default: Unspecified (null),
-  double lineHeight;
+  LineHeight lineHeight;
 
   //TODO modify these to match CSS styles
   String before;
@@ -230,7 +230,7 @@ class Style {
       letterSpacing: letterSpacing,
       shadows: textShadow,
       wordSpacing: wordSpacing,
-      height: lineHeight,
+      height: lineHeight?.size ?? 1.0,
       //TODO background
       //TODO textBaseline
     );
@@ -286,19 +286,25 @@ class Style {
   Style copyOnlyInherited(Style child) {
     if (child == null) return this;
 
+    FontSize finalFontSize = child.fontSize != null ?
+      fontSize != null && child.fontSize?.units == "em" ?
+        FontSize(child.fontSize.size * fontSize.size, "") : child.fontSize
+      : fontSize != null && fontSize.size < 0 ?
+        FontSize.percent(100) : fontSize;
+    LineHeight finalLineHeight = child.lineHeight != null ?
+      child.lineHeight?.units == "length" ?
+        LineHeight(child.lineHeight.size / (finalFontSize == null ? 14 : finalFontSize.size), "") : child.lineHeight
+      : lineHeight;
     return child.copyWith(
       color: child.color ?? color,
       direction: child.direction ?? direction,
       display: display == Display.NONE ? display : child.display,
       fontFamily: child.fontFamily ?? fontFamily,
       fontFeatureSettings: child.fontFeatureSettings ?? fontFeatureSettings,
-      fontSize: child.fontSize != null ?
-        fontSize != null && child.fontSize?.units == "em" ?
-          FontSize(child.fontSize.size * fontSize.size, "") : child.fontSize
-        : fontSize != null && fontSize.size < 0 ?
-          FontSize.percent(100) : fontSize,
+      fontSize: finalFontSize,
       fontStyle: child.fontStyle ?? fontStyle,
       fontWeight: child.fontWeight ?? fontWeight,
+      lineHeight: finalLineHeight,
       letterSpacing: child.letterSpacing ?? letterSpacing,
       listStyleType: child.listStyleType ?? listStyleType,
       listStylePosition: child.listStylePosition ?? listStylePosition,
@@ -320,7 +326,7 @@ class Style {
     FontStyle fontStyle,
     FontWeight fontWeight,
     double height,
-    double lineHeight,
+    LineHeight lineHeight,
     double letterSpacing,
     ListStyleType listStyleType,
     ListStylePosition listStylePosition,
@@ -393,7 +399,7 @@ class Style {
     this.letterSpacing = textStyle.letterSpacing;
     this.textShadow = textStyle.shadows;
     this.wordSpacing = textStyle.wordSpacing;
-    this.lineHeight = textStyle.height;
+    this.lineHeight = LineHeight(textStyle.height ?? 1.0, "");
   }
 }
 
@@ -421,7 +427,6 @@ class FontSize {
   }
 
   factory FontSize.rem(double rem) {
-    print(rem * 16 - 2);
     return FontSize(rem * 16 - 2, "rem");
   }
   // These values are calculated based off of the default (`medium`)
@@ -440,6 +445,31 @@ class FontSize {
   static const xxLarge = FontSize(28.0, "");
   static const smaller = FontSize(-0.83, "");
   static const larger = FontSize(-1.2, "");
+}
+
+class LineHeight {
+  final double size;
+  final String units;
+
+  const LineHeight(this.size, this.units);
+
+  factory LineHeight.percent(double percent) {
+    return LineHeight(percent / 100.0, "%");
+  }
+
+  factory LineHeight.em(double em) {
+    return LineHeight(em, "em");
+  }
+
+  factory LineHeight.rem(double rem) {
+    return LineHeight(rem, "rem");
+  }
+
+  factory LineHeight.number(double num) {
+    return LineHeight(num, "number");
+  }
+
+  static const normal = LineHeight(1.0, "");
 }
 
 enum ListStyleType {

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -291,7 +291,11 @@ class Style {
       direction: child.direction ?? direction,
       fontFamily: child.fontFamily ?? fontFamily,
       fontFeatureSettings: child.fontFeatureSettings ?? fontFeatureSettings,
-      fontSize: child.fontSize ?? fontSize,
+      fontSize: child.fontSize != null ?
+        fontSize != null && child.fontSize?.units == "em" ?
+          FontSize(child.fontSize.size * fontSize.size, "") : child.fontSize
+        : fontSize != null && fontSize.size < 0 ?
+          FontSize.percent(100) : fontSize,
       fontStyle: child.fontStyle ?? fontStyle,
       fontWeight: child.fontWeight ?? fontWeight,
       letterSpacing: child.letterSpacing ?? letterSpacing,
@@ -382,7 +386,7 @@ class Style {
     this.textDecorationThickness = textStyle.decorationThickness;
     this.fontFamily = textStyle.fontFamily;
     this.fontFeatureSettings = textStyle.fontFeatures;
-    this.fontSize = FontSize(textStyle.fontSize);
+    this.fontSize = FontSize(textStyle.fontSize, "");
     this.fontStyle = textStyle.fontStyle;
     this.fontWeight = textStyle.fontWeight;
     this.letterSpacing = textStyle.letterSpacing;
@@ -401,16 +405,22 @@ enum Display {
 
 class FontSize {
   final double size;
+  final String units;
 
-  const FontSize(this.size);
+  const FontSize(this.size, this.units);
 
   /// A percentage of the parent style's font size.
   factory FontSize.percent(int percent) {
-    return FontSize(percent.toDouble() / -100.0);
+    return FontSize(percent.toDouble() / -100.0, "%");
   }
 
-  factory FontSize.em(int em) {
-    return FontSize(em.toDouble() * 16 - 2);
+  factory FontSize.em(double em) {
+    return FontSize(em, "em");
+  }
+
+  factory FontSize.rem(double rem) {
+    print(rem * 16 - 2);
+    return FontSize(rem * 16 - 2, "rem");
   }
   // These values are calculated based off of the default (`medium`)
   // being 14px.
@@ -419,15 +429,15 @@ class FontSize {
   //
   // Negative values are computed during parsing to be a percentage of
   // the parent style's font size.
-  static const xxSmall = FontSize(7.875);
-  static const xSmall = FontSize(8.75);
-  static const small = FontSize(11.375);
-  static const medium = FontSize(14.0);
-  static const large = FontSize(15.75);
-  static const xLarge = FontSize(21.0);
-  static const xxLarge = FontSize(28.0);
-  static const smaller = FontSize(-0.83);
-  static const larger = FontSize(-1.2);
+  static const xxSmall = FontSize(7.875, "");
+  static const xSmall = FontSize(8.75, "");
+  static const small = FontSize(11.375, "");
+  static const medium = FontSize(14.0, "");
+  static const large = FontSize(15.75, "");
+  static const xLarge = FontSize(21.0, "");
+  static const xxLarge = FontSize(28.0, "");
+  static const smaller = FontSize(-0.83, "");
+  static const larger = FontSize(-1.2, "");
 }
 
 enum ListStyleType {

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -293,7 +293,7 @@ class Style {
         FontSize.percent(100) : fontSize;
     LineHeight finalLineHeight = child.lineHeight != null ?
       child.lineHeight?.units == "length" ?
-        LineHeight(child.lineHeight.size / (finalFontSize == null ? 14 : finalFontSize.size), "") : child.lineHeight
+        LineHeight(child.lineHeight.size / (finalFontSize == null ? 14 : finalFontSize.size) * 1.2, "") : child.lineHeight
       : lineHeight;
     return child.copyWith(
       color: child.color ?? color,
@@ -399,7 +399,7 @@ class Style {
     this.letterSpacing = textStyle.letterSpacing;
     this.textShadow = textStyle.shadows;
     this.wordSpacing = textStyle.wordSpacing;
-    this.lineHeight = LineHeight(textStyle.height ?? 1.0, "");
+    this.lineHeight = LineHeight(textStyle.height ?? 1.2, "");
   }
 }
 
@@ -454,22 +454,22 @@ class LineHeight {
   const LineHeight(this.size, this.units);
 
   factory LineHeight.percent(double percent) {
-    return LineHeight(percent / 100.0, "%");
+    return LineHeight(percent / 100.0 * 1.2, "%");
   }
 
   factory LineHeight.em(double em) {
-    return LineHeight(em, "em");
+    return LineHeight(em * 1.2, "em");
   }
 
   factory LineHeight.rem(double rem) {
-    return LineHeight(rem, "rem");
+    return LineHeight(rem * 1.2, "rem");
   }
 
   factory LineHeight.number(double num) {
-    return LineHeight(num, "number");
+    return LineHeight(num * 1.2, "number");
   }
 
-  static const normal = LineHeight(1.0, "");
+  static const normal = LineHeight(1.2, "");
 }
 
 enum ListStyleType {

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -288,12 +288,12 @@ class Style {
 
     FontSize finalFontSize = child.fontSize != null ?
       fontSize != null && child.fontSize?.units == "em" ?
-        FontSize(child.fontSize.size * fontSize.size, "") : child.fontSize
+        FontSize(child.fontSize.size * fontSize.size) : child.fontSize
       : fontSize != null && fontSize.size < 0 ?
         FontSize.percent(100) : fontSize;
     LineHeight finalLineHeight = child.lineHeight != null ?
       child.lineHeight?.units == "length" ?
-        LineHeight(child.lineHeight.size / (finalFontSize == null ? 14 : finalFontSize.size) * 1.2, "") : child.lineHeight
+        LineHeight(child.lineHeight.size / (finalFontSize == null ? 14 : finalFontSize.size) * 1.2) : child.lineHeight
       : lineHeight;
     return child.copyWith(
       color: child.color ?? color,
@@ -393,13 +393,13 @@ class Style {
     this.textDecorationThickness = textStyle.decorationThickness;
     this.fontFamily = textStyle.fontFamily;
     this.fontFeatureSettings = textStyle.fontFeatures;
-    this.fontSize = FontSize(textStyle.fontSize, "");
+    this.fontSize = FontSize(textStyle.fontSize);
     this.fontStyle = textStyle.fontStyle;
     this.fontWeight = textStyle.fontWeight;
     this.letterSpacing = textStyle.letterSpacing;
     this.textShadow = textStyle.shadows;
     this.wordSpacing = textStyle.wordSpacing;
-    this.lineHeight = LineHeight(textStyle.height ?? 1.2, "");
+    this.lineHeight = LineHeight(textStyle.height ?? 1.2);
   }
 }
 
@@ -415,19 +415,19 @@ class FontSize {
   final double size;
   final String units;
 
-  const FontSize(this.size, this.units);
+  const FontSize(this.size, {this.units = ""});
 
   /// A percentage of the parent style's font size.
   factory FontSize.percent(int percent) {
-    return FontSize(percent.toDouble() / -100.0, "%");
+    return FontSize(percent.toDouble() / -100.0, units: "%");
   }
 
   factory FontSize.em(double em) {
-    return FontSize(em, "em");
+    return FontSize(em, units: "em");
   }
 
   factory FontSize.rem(double rem) {
-    return FontSize(rem * 16 - 2, "rem");
+    return FontSize(rem * 16 - 2, units: "rem");
   }
   // These values are calculated based off of the default (`medium`)
   // being 14px.
@@ -436,40 +436,40 @@ class FontSize {
   //
   // Negative values are computed during parsing to be a percentage of
   // the parent style's font size.
-  static const xxSmall = FontSize(7.875, "");
-  static const xSmall = FontSize(8.75, "");
-  static const small = FontSize(11.375, "");
-  static const medium = FontSize(14.0, "");
-  static const large = FontSize(15.75, "");
-  static const xLarge = FontSize(21.0, "");
-  static const xxLarge = FontSize(28.0, "");
-  static const smaller = FontSize(-0.83, "");
-  static const larger = FontSize(-1.2, "");
+  static const xxSmall = FontSize(7.875);
+  static const xSmall = FontSize(8.75);
+  static const small = FontSize(11.375);
+  static const medium = FontSize(14.0);
+  static const large = FontSize(15.75);
+  static const xLarge = FontSize(21.0);
+  static const xxLarge = FontSize(28.0);
+  static const smaller = FontSize(-0.83);
+  static const larger = FontSize(-1.2);
 }
 
 class LineHeight {
   final double size;
   final String units;
 
-  const LineHeight(this.size, this.units);
+  const LineHeight(this.size, {this.units = ""});
 
   factory LineHeight.percent(double percent) {
-    return LineHeight(percent / 100.0 * 1.2, "%");
+    return LineHeight(percent / 100.0 * 1.2, units: "%");
   }
 
   factory LineHeight.em(double em) {
-    return LineHeight(em * 1.2, "em");
+    return LineHeight(em * 1.2, units: "em");
   }
 
   factory LineHeight.rem(double rem) {
-    return LineHeight(rem * 1.2, "rem");
+    return LineHeight(rem * 1.2, units: "rem");
   }
 
   factory LineHeight.number(double num) {
-    return LineHeight(num * 1.2, "number");
+    return LineHeight(num * 1.2, units: "number");
   }
 
-  static const normal = LineHeight(1.2, "");
+  static const normal = LineHeight(1.2);
 }
 
 enum ListStyleType {

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -289,6 +289,7 @@ class Style {
     return child.copyWith(
       color: child.color ?? color,
       direction: child.direction ?? direction,
+      display: display == Display.NONE ? display : child.display,
       fontFamily: child.fontFamily ?? fontFamily,
       fontFeatureSettings: child.fontFeatureSettings ?? fontFeatureSettings,
       fontSize: child.fontSize != null ?
@@ -401,6 +402,7 @@ enum Display {
   INLINE,
   INLINE_BLOCK,
   LIST_ITEM,
+  NONE,
 }
 
 class FontSize {


### PR DESCRIPTION
Fixes #516, implements everything that was WIP in #228.

Implements direction, display, font-feature-settings, font-family, font-style, font-size, font-weight, line-height, text-decoration, text-decoration-line, text-decoration-color, text-decoration-style, and text-shadow support based on CSS guidelines. 

Added `Display.NONE` to the existing `Display` enums to allow `style="display: none;"`

Preview:

![image](https://user-images.githubusercontent.com/50850142/106771549-118d1a00-660d-11eb-95d3-c727248f4f92.png)

Code for above example:
```
<p style="direction: rtl;">This text should go from right to left</p>
<p style="display: none;">This text should not show up</p>
<p style="font-feature-settings: smcp 1;">This text's lower case letters should be small capital</p>
<p style="font-family: times;">This text should be in Times New Roman</p>
<p style="font-style: italic; font-family: monospace;">This text should be italic and in monospace</p>
<p style="font-weight: bold;">This text should be bold</p>
<p style="line-height: 3">This is going to be a really long text element just to test line height which I have set in the style of this paragraph to be three times the height of this paragraph's font size.</p>
<p style="line-height: 100%">This is going to be a really long text element just to display the default line height which is the same as the height of this paragraph's font size multiplied by 1.2 as per CSS spec.</p>
<p style="text-shadow: 2 2, 0 0 5px #DE6721;">This text should have a really weird text shadow</p>
<p style="text-decoration: underline overline line-through #DE6721 wavy;">This text should have some fancy text decorations</p>
```

This is going to need some pretty rigorous testing imo, there's a lot of different variables to consider when creating the inline style implementations so I want to make sure as many edge-cases are covered as possible.