### PR TITLE
Support relative paths for network image rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@ The default image renders are:
 ```dart
 final Map<ImageSourceMatcher, ImageRender> defaultImageRenders = {
   base64UriMatcher(): base64ImageRender(),
+  assetUriMatcher(): assetImageRender(),
   networkSourceMatcher(extension: "svg"): svgNetworkImageRender(),
   networkSourceMatcher(): networkImageRender(),
 };
@@ -535,12 +536,16 @@ Widget html = Html(
       headers: {"Custom-Header": "some-value"},
       altWidget: (alt) => Text(alt),
     ),
+            (attr, _) => attr["src"] != null && attr["src"].startsWith("/wiki"):
+    networkImageRender(
+            mapUrl: (url) => "https://upload.wikimedia.org" + url),
   },
 );
 ```
 
-Above, there are two `networkSourceMatcher`s. One is overriden to only apply to images on the URL `flutter.dev`, while the other covers the rest of the cases.
-When an image with URL `flutter.dev` is detected, rather than displaying the image, the render will display the flutter logo. If the image is any other image, it keeps the default widget, but just sets the headers and the alt text in case that image happens to be broken. 
+Above, there are three custom `networkSourceMatcher`s, which will be applied - in order - before the default implementations. 
+
+When an image with URL `flutter.dev` is detected, rather than displaying the image, the render will display the flutter logo. If the image is any other image, it keeps the default widget, but just sets the headers and the alt text in case that image happens to be broken. The final render handles relative paths by rewriting them, specifically prefixing them with a base url. Note that the customizations of the previous custom renders do not apply. For example, the headers that the second render would apply are not applied in this third render.  
 
 2. Creating your own renders:
 ```dart

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -136,24 +136,6 @@ const htmlData = """
       <img alt='Empty source' src='' />
       <h3>Broken network image</h3>
       <img alt='Broken image' src='https://www.notgoogle.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' />
-      <h3>Used inside a table</h3>
-      <table>
-      <tr>
-      <td><img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' /></td>
-      <td><img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' /></td>
-      <td><img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' /></td>
-      </tr>
-      </table>
-      <h3>Video support:</h3>
-      <video controls>
-        <source src="https://www.w3schools.com/html/mov_bbb.mp4" />
-      </video>
-      <h3>Audio support:</h3>
-      <audio controls>
-        <source src="https://www.w3schools.com/html/mov_bbb.mp4" />
-      </audio>
-      <h3>IFrame support:</h3>
-      <iframe src="https://google.com"></iframe>
 """;
 
 class _MyHomePageState extends State<MyHomePage> {
@@ -177,9 +159,12 @@ class _MyHomePageState extends State<MyHomePage> {
               headers: {"Custom-Header": "some-value"},
               altWidget: (alt) => Text(alt),
             ),
+            // On relative paths starting with /wiki, prefix with a base url
             (attr, _) => attr["src"] != null && attr["src"].startsWith("/wiki"):
                 networkImageRender(
                     mapUrl: (url) => "https://upload.wikimedia.org" + url),
+            // Custom placeholder image for broken links
+            networkSourceMatcher(): networkImageRender(altWidget: (_) => FlutterLogo()),
           },
           onLinkTap: (url) {
             print("Opening $url...");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -127,6 +127,8 @@ const htmlData = """
       <img src='asset:assets/mac.svg' width='100' />
       <h3>Base64</h3>
       <img alt='Red dot' src='data:image/png;base64, iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO9TXL0Y4OHwAAAABJRU5ErkJggg==' />
+      <h3>Custom source matcher (relative paths)</h3>
+      <img src='/wikipedia/commons/thumb/e/ef/Octicons-logo-github.svg/200px-Octicons-logo-github.svg.png' />
       <h3>Custom image render (flutter.dev)</h3>
       <img src='https://flutter.dev/images/flutter-mono-81x100.png' />
       <h3>No image source</h3>
@@ -175,6 +177,8 @@ class _MyHomePageState extends State<MyHomePage> {
               headers: {"Custom-Header": "some-value"},
               altWidget: (alt) => Text(alt),
             ),
+            (attr, _) => attr["src"] != null && attr["src"].startsWith("/wiki"):
+                networkImageRender(baseUrl: "https://upload.wikimedia.org"),
           },
           onLinkTap: (url) {
             print("Opening $url...");

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -178,7 +178,8 @@ class _MyHomePageState extends State<MyHomePage> {
               altWidget: (alt) => Text(alt),
             ),
             (attr, _) => attr["src"] != null && attr["src"].startsWith("/wiki"):
-                networkImageRender(baseUrl: "https://upload.wikimedia.org"),
+                networkImageRender(
+                    mapUrl: (url) => "https://upload.wikimedia.org" + url),
           },
           onLinkTap: (url) {
             print("Opening $url...");

--- a/lib/image_render.dart
+++ b/lib/image_render.dart
@@ -90,14 +90,13 @@ ImageRender assetImageRender({
 
 ImageRender networkImageRender({
   Map<String, String> headers,
-  String baseUrl,
+  String Function(String) mapUrl,
   double width,
   double height,
   Widget Function(String) altWidget,
 }) =>
     (context, attributes, element) {
-      final src =
-          baseUrl != null ? baseUrl + _src(attributes) : _src(attributes);
+      final src = mapUrl?.call(_src(attributes)) ?? _src(attributes);
       precacheImage(
         NetworkImage(
           src,

--- a/lib/image_render.dart
+++ b/lib/image_render.dart
@@ -153,7 +153,7 @@ ImageRender networkImageRender({
               },
             );
           } else if (snapshot.hasError) {
-            return Text(_alt(attributes) ?? "",
+            return altWidget?.call(_alt(attributes)) ?? Text(_alt(attributes) ?? "",
                 style: context.style.generateTextStyle());
           } else {
             return new CircularProgressIndicator();

--- a/lib/image_render.dart
+++ b/lib/image_render.dart
@@ -90,14 +90,17 @@ ImageRender assetImageRender({
 
 ImageRender networkImageRender({
   Map<String, String> headers,
+  String baseUrl,
   double width,
   double height,
   Widget Function(String) altWidget,
 }) =>
     (context, attributes, element) {
+      final src =
+          baseUrl != null ? baseUrl + _src(attributes) : _src(attributes);
       precacheImage(
         NetworkImage(
-          _src(attributes),
+          src,
           headers: headers,
         ),
         context.buildContext,
@@ -107,7 +110,7 @@ ImageRender networkImageRender({
       );
       Completer<Size> completer = Completer();
       Image image =
-          Image.network(_src(attributes), frameBuilder: (ctx, child, frame, _) {
+          Image.network(src, frameBuilder: (ctx, child, frame, _) {
         if (frame == null) {
           if (!completer.isCompleted) {
             completer.completeError("error");
@@ -137,7 +140,7 @@ ImageRender networkImageRender({
         builder: (BuildContext buildContext, AsyncSnapshot<Size> snapshot) {
           if (snapshot.hasData) {
             return Image.network(
-              _src(attributes),
+              src,
               headers: headers,
               width: width ?? _width(attributes) ?? snapshot.data.width,
               height: height ?? _height(attributes),


### PR DESCRIPTION
Implemented relative paths in image loading via custom image render API.

Whilst this still require modest manual work (by setting the custom image render), it solves this fairly common use case with little effort from users, and still offering much flexibility.

```
            // Install a custum render for all relative paths that start with the /wiki prefix
            (attr, _) => attr["src"] != null && attr["src"].startsWith("/wiki"):
                networkImageRender(baseUrl: "https://upload.wikimedia.org"),
```

Fixes #153 and closes #146