### PR TITLE
Update documentation and bump version in advance of 1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.3.0] - February 9, 2021:
+* New image loading API
+* Image loading with request headers, from relative paths and custom loading widget
+* SVG image support from network or local assets
+* Support for `<details>`/`<summary>` tags
+* Allow returning spans from custom tag renders
+* Inline font styling
+* Content-based table column sizing
+* Respect iframe sandbox attribute
+* Fixed text flow and styling when using tags inside `<a>` links
+* Updated dependencies for Flutter 1.26+
+
 ## [1.2.0] - January 14, 2021:
 * Support irregular table sizes
 * Allow for returning `null` from a customRender function to disable the widget

--- a/README.md
+++ b/README.md
@@ -35,43 +35,27 @@ A Flutter widget for rendering HTML and CSS as Flutter widgets.
 
   - [Data](#data)
 
-    - [Example](#example-usage---data)
-
   - [onLinkTap](#onlinktap)
-
-    - [Example](#example-usage---onlinktap)
 
   - [customRender](#customrender)
 
-    - [Example](#example-usages---customrender)
-
   - [onImageError](#onimageerror)
-
-    - [Example](#example-usage---onimageerror)
 
   - [onImageTap](#onimagetap)
 
-    - [Example](#example-usage---onimagetap)
-
   - [blacklistedElements](#blacklistedelements)
-
-    - [Example](#example-usage---blacklistedelements)
 
   - [style](#style)
 
-    - [Example](#example-usage---style)
-
   - [navigationDelegateForIframe](#navigationdelegateforiframe)
 
-    - [Example](#example-usage---navigationdelegateforiframe)
-    
   - [customImageRender](#customimagerender)
   
     - [typedef ImageSourceMatcher (with examples)](#typedef-imagesourcematcher)
     
     - [typedef ImageRender (with examples)](#typedef-imagerender)
     
-    - [Examples](#example-usages---customimagerender)
+    - [Extended examples](#example-usages---customimagerender)
     
 - [Rendering Reference](#rendering-reference)
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ A Flutter widget for rendering HTML and CSS as Flutter widgets.
 Add the following to your `pubspec.yaml` file:
 
     dependencies:
-      flutter_html: ^1.2.0
+      flutter_html: ^1.3.0
 
 ## Currently Supported HTML Tags:
 |            |           |       |             |         |         |       |      |        |        |        |

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_html
 description: A Flutter widget rendering static HTML and CSS as Flutter widgets.
-version: 1.2.0
+version: 1.3.0
 homepage: https://github.com/Sub6Resources/flutter_html
 
 environment:


### PR DESCRIPTION
Updates the readme.

I'm not sure if we should explicitly bump the min Flutter version to 1.26, as practically the required dependencies now really need that, but we apparently didn't do this before? 