### PR TITLE
Add support for anchor links within the same document

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -146,6 +146,12 @@ class _MyHomePageState extends State<MyHomePage> {
         title: Text('flutter_html Example'),
         centerTitle: true,
       ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          Html.scrollToTop();
+        },
+        child: Icon(Icons.expand_less)
+      ),
       body: SingleChildScrollView(
         child: Html(
           data: htmlData,

--- a/lib/flutter_html.dart
+++ b/lib/flutter_html.dart
@@ -1,6 +1,7 @@
 library flutter_html;
 
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_html/html_parser.dart';
 import 'package:flutter_html/image_render.dart';
 import 'package:flutter_html/style.dart';
@@ -68,6 +69,33 @@ class Html extends StatelessWidget {
   /// Iframe. It's necessary to use the webview_flutter package inside the app
   /// to use NavigationDelegate.
   final NavigationDelegate navigationDelegateForIframe;
+
+  /// Scrolls the HTML widget to the top.
+  /// You can set the duration and curve to use, by default the duration is 100ms and the curve is [Curves.easeIn]
+  /// This method should not be called until the widget is fully built.
+  static void scrollToTop({Duration duration, Curves curve}) {
+    final context = scrollContext;
+    final renderObject = context.findRenderObject();
+    if (renderObject == null) return;
+
+    final offsetToReveal = RenderAbstractViewport.of(renderObject)
+        ?.getOffsetToReveal(renderObject, 0.0)
+        ?.offset;
+    final position = Scrollable.of(scrollContext)?.position;
+    if (offsetToReveal == null || position == null) return;
+
+    final alignment = (position.pixels > offsetToReveal)
+        ? 0.0
+        : (position.pixels < offsetToReveal ? 1.0 : null);
+    if (alignment == null) return;
+
+    position.ensureVisible(
+      renderObject,
+      alignment: alignment,
+      duration: duration ?? const Duration(milliseconds: 100),
+      curve: curve ?? Curves.easeIn,
+    );
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,4 +1,7 @@
+import 'dart:ui';
+
 import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
 
 class Context<T> {
   T data;
@@ -41,5 +44,124 @@ class MultipleTapGestureRecognizer extends TapGestureRecognizer {
       acceptGesture(pointer);
       _ready = false;
     }
+  }
+}
+
+/// This class is a placeholder class so that the renderer can distinguish
+/// between WidgetSpans and TextSpans
+class CustomTextSpan extends WidgetSpan {
+  const CustomTextSpan({
+    this.child,
+    this.inlineSpanChild,
+    PlaceholderAlignment alignment = PlaceholderAlignment.bottom,
+    TextBaseline baseline,
+    TextStyle style,
+  }) : assert(child != null),
+        assert(baseline != null || !(
+            identical(alignment, PlaceholderAlignment.aboveBaseline) ||
+                identical(alignment, PlaceholderAlignment.belowBaseline) ||
+                identical(alignment, PlaceholderAlignment.baseline)
+        )),
+        super(
+        alignment: alignment,
+        baseline: baseline,
+        style: style,
+        child: child,
+      );
+
+  final Widget child;
+  final InlineSpan inlineSpanChild;
+
+  @override
+  void build(ParagraphBuilder builder, { double textScaleFactor = 1.0, List<PlaceholderDimensions> dimensions }) {
+    assert(debugAssertIsValid());
+    assert(dimensions != null);
+    final bool hasStyle = style != null;
+    if (hasStyle) {
+      builder.pushStyle(style.getTextStyle(textScaleFactor: textScaleFactor));
+    }
+    assert(builder.placeholderCount < dimensions.length);
+    final PlaceholderDimensions currentDimensions = dimensions[builder.placeholderCount];
+    builder.addPlaceholder(
+      currentDimensions.size.width,
+      currentDimensions.size.height,
+      alignment,
+      scale: textScaleFactor,
+      baseline: currentDimensions.baseline,
+      baselineOffset: currentDimensions.baselineOffset,
+    );
+    if (hasStyle) {
+      builder.pop();
+    }
+  }
+
+  @override
+  bool visitChildren(InlineSpanVisitor visitor) {
+    return visitor(this);
+  }
+
+  @override
+  InlineSpan getSpanForPositionVisitor(TextPosition position, Accumulator offset) {
+    if (position.offset == offset.value) {
+      return this;
+    }
+    offset.increment(1);
+    return null;
+  }
+
+  @override
+  int codeUnitAtVisitor(int index, Accumulator offset) {
+    return null;
+  }
+
+  @override
+  RenderComparison compareTo(InlineSpan other) {
+    if (identical(this, other))
+      return RenderComparison.identical;
+    if (other.runtimeType != runtimeType)
+      return RenderComparison.layout;
+    if ((style == null) != (other.style == null))
+      return RenderComparison.layout;
+    final WidgetSpan typedOther = other as WidgetSpan;
+    if (child != typedOther.child || alignment != typedOther.alignment) {
+      return RenderComparison.layout;
+    }
+    RenderComparison result = RenderComparison.identical;
+    if (style != null) {
+      final RenderComparison candidate = style.compareTo(other.style);
+      if (candidate.index > result.index)
+        result = candidate;
+      if (result == RenderComparison.layout)
+        return result;
+    }
+    return result;
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other))
+      return true;
+    if (other.runtimeType != runtimeType)
+      return false;
+    if (super != other)
+      return false;
+    return other is WidgetSpan
+        && other.child == child
+        && other.alignment == alignment
+        && other.baseline == baseline;
+  }
+
+  @override
+  int get hashCode => hashValues(super.hashCode, child, alignment, baseline);
+
+  @override
+  InlineSpan getSpanForPosition(TextPosition position) {
+    assert(debugAssertIsValid());
+    return null;
+  }
+
+  @override
+  bool debugAssertIsValid() {
+    return true;
   }
 }

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -214,6 +214,26 @@ class Style {
     }
   }
 
+  Style generateFromTextStyle(TextStyle style) {
+    return Style(
+      backgroundColor: style.backgroundColor,
+      color: style.color,
+      fontFamily: style.fontFamily,
+      fontFeatureSettings: style.fontFeatures,
+      fontSize: FontSize(style.fontSize),
+      fontStyle: style.fontStyle,
+      fontWeight: style.fontWeight,
+      height: style.height,
+      lineHeight: LineHeight(style.height),
+      letterSpacing: style.letterSpacing,
+      textDecoration: style.decoration,
+      textDecorationColor: style.decorationColor,
+      textDecorationStyle: style.decorationStyle,
+      textDecorationThickness: style.decorationThickness,
+      textShadow: style.shadows,
+    );
+  }
+
   TextStyle generateTextStyle() {
     return TextStyle(
       backgroundColor: backgroundColor,


### PR DESCRIPTION
Possibly fixes #268 

I'm going to open this by saying I'm *not* too particularly proud of this PR. I've been working on this since Saturday and haven't been able to achieve something I'm satisfied with - this solution just seems awfully hacky to me.

First, I tried using globalkeys to get the current context and then the render object, but the current context would come back as null no matter what I did.

Then I transitioned to a `Builder` to get the `buildContext` which does work, but came with another whole host of issues since you can't return `InlineSpan`s. I tried using `WidgetSpan`s everywhere at first, lots of errors. Then I made this class that extends the `WidgetSpan` and has a field to input the original inline span for use when rendering the links. This has worked, but as I said, I think its pretty hacky. 

I bet there's also a way to significantly slim down the `CustomTextSpan` class, but I don't know the best way to go about that.

@erickok if you could check and make sure this doesn't break all the fixes you made for links that would be great - I did checking on my part and it seems fine.


As for the PR itself, it supports scrolling to anchor links when one is pressed. I also added a method to the `Html` widget where the user can scroll the widget to the top from anywhere, in the example app I used a floating action button to demonstrate this.