### PR TITLE
[URGENT] fix for `copyOnlyInherited on null` error after shrinkWrap fixes

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -68,6 +68,7 @@ class HtmlParser extends StatelessWidget {
       RenderContext(
         buildContext: context,
         parser: this,
+        style: Style.fromTextStyle(Theme.of(context).textTheme.bodyText2),
       ),
       cleanedTree,
     );
@@ -247,7 +248,7 @@ class HtmlParser extends StatelessWidget {
     RenderContext newContext = RenderContext(
       buildContext: context.buildContext,
       parser: this,
-      style: context.style?.copyOnlyInherited(tree.style) ?? Style.fromTextStyle(Theme.of(context.buildContext).textTheme.bodyText2),
+      style: context.style?.copyOnlyInherited(tree.style),
     );
 
     if (customRender?.containsKey(tree.name) ?? false) {

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -247,7 +247,7 @@ class HtmlParser extends StatelessWidget {
     RenderContext newContext = RenderContext(
       buildContext: context.buildContext,
       parser: this,
-      style: context.style.copyOnlyInherited(tree.style),
+      style: context.style?.copyOnlyInherited(tree.style) ?? Style.fromTextStyle(Theme.of(context.buildContext).textTheme.bodyText2),
     );
 
     if (customRender?.containsKey(tree.name) ?? false) {


### PR DESCRIPTION
This cropped up out of nowhere, it wasn't happening in my testing beforehand. This fixes that issue and doesn't introduce any regressions or other issues as far as I can tell.

@ryan-berger this will need to be merged or a fix will need to be found before 1.3.0 goes to pub.