### PR TITLE
Add support for base64 encoded SVG within img tag

### DIFF
--- a/lib/src/replaced_element.dart
+++ b/lib/src/replaced_element.dart
@@ -346,9 +346,9 @@ ReplacedElement parseReplacedElement(
           return SvgContentElement(
             data: svg,
             width: double.tryParse(
-                RegExp(r"width=\'([0-9.]+)\'").firstMatch(svg).group(1) ?? ""),
+                RegExp(r"width=\'([0-9.]+)").firstMatch(svg).group(1) ?? ""),
             height: double.tryParse(
-                RegExp(r"height=\'([0-9.]+)\'").firstMatch(svg).group(1) ?? ""),
+                RegExp(r"height=\'([0-9.]+)").firstMatch(svg).group(1) ?? ""),
           );
         } catch (e) {
           return SvgContentElement(

--- a/lib/src/replaced_element.dart
+++ b/lib/src/replaced_element.dart
@@ -355,14 +355,13 @@ ReplacedElement parseReplacedElement(
             data: svg,
           );
         }
-      } else {
-        return ImageContentElement(
-          name: "img",
-          src: element.attributes['src'],
-          alt: element.attributes['alt'],
-          node: element,
-        );
       }
+      return ImageContentElement(
+        name: "img",
+        src: element.attributes['src'],
+        alt: element.attributes['alt'],
+        node: element,
+      );
     case "video":
       final sources = <String>[
         if (element.attributes['src'] != null) element.attributes['src'],


### PR DESCRIPTION
Earlier all img tags were treated as a png or jpg image. But this PR ensures that img tags with base64 encoded SVG data gets parsed as SvgContentElement