### PR TITLE
Fix nested bg color not showing through

### DIFF
--- a/lib/style.dart
+++ b/lib/style.dart
@@ -292,6 +292,8 @@ class Style {
         LineHeight(child.lineHeight!.size! / (finalFontSize == null ? 14 : finalFontSize.size!) * 1.2) : child.lineHeight
       : lineHeight;
     return child.copyWith(
+      backgroundColor: child.backgroundColor != Colors.transparent ?
+        child.backgroundColor : backgroundColor,
       color: child.color ?? color,
       direction: child.direction ?? direction,
       display: display == Display.NONE ? display : child.display,


### PR DESCRIPTION
Fixes #571

Technically bg color isn't inherited but the default value is Colors.transparent so the parent bg color should shine through. This is effectively a workaround to reproduce that behavior.

From [w3.org](http://w3.org/TR/WD-CSS2-971104/colors.html):

> Background properties do not inherit, but the parent element's background will shine through by default because of the initial 'transparent' value on 'background-color'.