### PR TITLE
[URGENT] Fix lists not rendering correctly

### DIFF
--- a/lib/style.dart
+++ b/lib/style.dart
@@ -189,7 +189,7 @@ class Style {
     this.lineHeight,
     this.letterSpacing,
     this.listStyleType,
-    this.listStylePosition,
+    this.listStylePosition = ListStylePosition.OUTSIDE,
     this.padding,
     this.margin,
     this.textAlign,


### PR DESCRIPTION
Regression introduced in nullsafety pre-release that caused lists to be indented correctly but not show the bullet point or numbering.

This is a minor fix to correct it.

This one is really odd, don't know what exactly caused it.