### PR TITLE
Fixes a crash when using table cell rowspans in different columns

### DIFF
--- a/lib/src/layout_element.dart
+++ b/lib/src/layout_element.dart
@@ -95,7 +95,7 @@ class TableLayoutElement extends LayoutElement {
     for (var row in rows) {
       int columni = 0;
       for (var child in row.children) {
-        if (columnRowOffset[columni] > 0) {
+        while (columnRowOffset[columni] > 0) {
           columnRowOffset[columni] = columnRowOffset[columni] - 1;
           columni++;
         }


### PR DESCRIPTION
Fixes #581 which caused a crash when using table cell rowspans in different columns

![Screenshot 2021-03-13 at 01 28 37](https://user-images.githubusercontent.com/196453/111011947-702b7d80-839b-11eb-8c53-1879fef7ac69.png)
