### PR TITLE
Fix text decoration not cascading between children and parent

### DIFF
--- a/lib/style.dart
+++ b/lib/style.dart
@@ -307,6 +307,9 @@ class Style {
       listStyleType: child.listStyleType ?? listStyleType,
       listStylePosition: child.listStylePosition ?? listStylePosition,
       textAlign: child.textAlign ?? textAlign,
+      textDecoration: TextDecoration.combine(
+          [child.textDecoration ?? TextDecoration.none,
+            textDecoration ?? TextDecoration.none]),
       textShadow: child.textShadow ?? textShadow,
       whiteSpace: child.whiteSpace ?? whiteSpace,
       wordSpacing: child.wordSpacing ?? wordSpacing,


### PR DESCRIPTION
Fixes #594

Technically text-decoration isn't inherited, but it visually functions that way - the parent text decoration will draw on the box containing the child.