### PR TITLE
Add support for more inline styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,9 @@ Add the following to your `pubspec.yaml` file:
 ## Currently Supported Inline CSS Attributes:
 |                  |        |            |          |              |                        |            |
 |------------------|--------|------------|----------|--------------|------------------------|------------|
-|`background-color`| `border` | `color`| `direction`| `display`| `font-family`| `font-feature-settings` |
-| `font-size`|`font-style`      | `font-weight`| `line-height` | `list-style-type`  | `list-style-position`|`padding`     |
-| `margin`| `text-align`| `text-decoration`| `text-decoration-color`| `text-decoration-style`| `text-shadow` | |
+|`background-color`| `border` (including specific directions) | `color`| `direction`| `display`| `font-family`| `font-feature-settings` |
+| `font-size`|`font-style`      | `font-weight`| `line-height` | `list-style-type`  | `list-style-position`|`padding`  (including specific directions)   |
+| `margin` (including specific directions) | `text-align`| `text-decoration`| `text-decoration-color`| `text-decoration-style`| `text-shadow` | |
 
 Don't see a tag or attribute you need? File a feature request or contribute to the project!
 

--- a/example/lib/generated_plugin_registrant.dart
+++ b/example/lib/generated_plugin_registrant.dart
@@ -4,7 +4,6 @@
 
 // ignore_for_file: lines_longer_than_80_chars
 
-import 'package:url_launcher_web/url_launcher_web.dart';
 import 'package:video_player_web/video_player_web.dart';
 import 'package:wakelock_web/wakelock_web.dart';
 
@@ -12,7 +11,6 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
 // ignore: public_member_api_docs
 void registerPlugins(Registrar registrar) {
-  UrlLauncherPlugin.registerWith(registrar);
   VideoPlayerPlugin.registerWith(registrar);
   WakelockWeb.registerWith(registrar);
   registrar.registerMessageHandler();

--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -18,20 +18,152 @@ Style declarationsToStyle(Map<String?, List<css.Expression>> declarations) {
         case 'border':
           List<css.LiteralTerm?>? borderWidths = value.whereType<css.LiteralTerm>().toList();
           /// List<css.LiteralTerm> might include other values than the ones we want for [BorderSide.width], so make sure to remove those before passing it to [ExpressionMapping]
-          borderWidths.removeWhere((element) => element != null && element.text != "thin" 
+          borderWidths.removeWhere((element) => element == null || (element.text != "thin"
               && element.text != "medium" && element.text != "thick"
-              && !(element is css.LengthTerm) && !(element is css.PercentageTerm) 
-              && !(element is css.EmTerm) && !(element is css.RemTerm) 
-              && !(element is css.NumberTerm)
+              && !(element is css.LengthTerm) && !(element is css.PercentageTerm)
+              && !(element is css.EmTerm) && !(element is css.RemTerm)
+              && !(element is css.NumberTerm))
           );
           List<css.Expression?>? borderColors = value.where((element) => ExpressionMapping.expressionToColor(element) != null).toList();
           List<css.LiteralTerm?>? potentialStyles = value.whereType<css.LiteralTerm>().toList();
           /// Currently doesn't matter, as Flutter only supports "solid" or "none", but may support more in the future.
           List<String> possibleBorderValues = ["dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset", "none", "hidden"];
           /// List<css.LiteralTerm> might include other values than the ones we want for [BorderSide.style], so make sure to remove those before passing it to [ExpressionMapping]
-          potentialStyles.removeWhere((element) => element != null && !possibleBorderValues.contains(element.text));
+          potentialStyles.removeWhere((element) => element == null || !possibleBorderValues.contains(element.text));
           List<css.LiteralTerm?>? borderStyles = potentialStyles;
           style.border = ExpressionMapping.expressionToBorder(borderWidths, borderStyles, borderColors);
+          break;
+        case 'border-left':
+          List<css.LiteralTerm?>? borderWidths = value.whereType<css.LiteralTerm>().toList();
+          /// List<css.LiteralTerm> might include other values than the ones we want for [BorderSide.width], so make sure to remove those before passing it to [ExpressionMapping]
+          borderWidths.removeWhere((element) => element == null || (element.text != "thin"
+              && element.text != "medium" && element.text != "thick"
+              && !(element is css.LengthTerm) && !(element is css.PercentageTerm)
+              && !(element is css.EmTerm) && !(element is css.RemTerm)
+              && !(element is css.NumberTerm))
+          );
+          css.LiteralTerm borderWidth = borderWidths.firstWhere((element) => element != null)!;
+          css.Expression borderColor = value.firstWhere((element) => ExpressionMapping.expressionToColor(element) != null);
+          List<css.LiteralTerm?>? potentialStyles = value.whereType<css.LiteralTerm>().toList();
+          /// Currently doesn't matter, as Flutter only supports "solid" or "none", but may support more in the future.
+          List<String> possibleBorderValues = ["dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset", "none", "hidden"];
+          /// List<css.LiteralTerm> might include other values than the ones we want for [BorderSide.style], so make sure to remove those before passing it to [ExpressionMapping]
+          potentialStyles.removeWhere((element) => element == null || !possibleBorderValues.contains(element.text));
+          css.LiteralTerm borderStyle = potentialStyles.first!;
+          Border newBorder = Border(
+            left: style.border?.left.copyWith(
+              width: ExpressionMapping.expressionToBorderWidth(borderWidth),
+              style: ExpressionMapping.expressionToBorderStyle(borderStyle),
+              color: ExpressionMapping.expressionToColor(borderColor),
+            ) ?? BorderSide(
+              width: ExpressionMapping.expressionToBorderWidth(borderWidth),
+              style: ExpressionMapping.expressionToBorderStyle(borderStyle),
+              color: ExpressionMapping.expressionToColor(borderColor) ?? Colors.black,
+            ),
+            right: style.border?.right ?? BorderSide.none,
+            top: style.border?.top ?? BorderSide.none,
+            bottom: style.border?.bottom ?? BorderSide.none,
+          );
+          style.border = newBorder;
+          break;
+        case 'border-right':
+          List<css.LiteralTerm?>? borderWidths = value.whereType<css.LiteralTerm>().toList();
+          /// List<css.LiteralTerm> might include other values than the ones we want for [BorderSide.width], so make sure to remove those before passing it to [ExpressionMapping]
+          borderWidths.removeWhere((element) => element == null || (element.text != "thin"
+              && element.text != "medium" && element.text != "thick"
+              && !(element is css.LengthTerm) && !(element is css.PercentageTerm)
+              && !(element is css.EmTerm) && !(element is css.RemTerm)
+              && !(element is css.NumberTerm))
+          );
+          css.LiteralTerm borderWidth = borderWidths.firstWhere((element) => element != null)!;
+          css.Expression borderColor = value.firstWhere((element) => ExpressionMapping.expressionToColor(element) != null);
+          List<css.LiteralTerm?>? potentialStyles = value.whereType<css.LiteralTerm>().toList();
+          /// Currently doesn't matter, as Flutter only supports "solid" or "none", but may support more in the future.
+          List<String> possibleBorderValues = ["dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset", "none", "hidden"];
+          /// List<css.LiteralTerm> might include other values than the ones we want for [BorderSide.style], so make sure to remove those before passing it to [ExpressionMapping]
+          potentialStyles.removeWhere((element) => element == null || !possibleBorderValues.contains(element.text));
+          css.LiteralTerm borderStyle = potentialStyles.first!;
+          Border newBorder = Border(
+            left: style.border?.left ?? BorderSide.none,
+            right: style.border?.right.copyWith(
+              width: ExpressionMapping.expressionToBorderWidth(borderWidth),
+              style: ExpressionMapping.expressionToBorderStyle(borderStyle),
+              color: ExpressionMapping.expressionToColor(borderColor),
+            ) ?? BorderSide(
+              width: ExpressionMapping.expressionToBorderWidth(borderWidth),
+              style: ExpressionMapping.expressionToBorderStyle(borderStyle),
+              color: ExpressionMapping.expressionToColor(borderColor) ?? Colors.black,
+            ),
+            top: style.border?.top ?? BorderSide.none,
+            bottom: style.border?.bottom ?? BorderSide.none,
+          );
+          style.border = newBorder;
+          break;
+        case 'border-top':
+          List<css.LiteralTerm?>? borderWidths = value.whereType<css.LiteralTerm>().toList();
+          /// List<css.LiteralTerm> might include other values than the ones we want for [BorderSide.width], so make sure to remove those before passing it to [ExpressionMapping]
+          borderWidths.removeWhere((element) => element == null || (element.text != "thin"
+              && element.text != "medium" && element.text != "thick"
+              && !(element is css.LengthTerm) && !(element is css.PercentageTerm)
+              && !(element is css.EmTerm) && !(element is css.RemTerm)
+              && !(element is css.NumberTerm))
+          );
+          css.LiteralTerm borderWidth = borderWidths.firstWhere((element) => element != null)!;
+          css.Expression borderColor = value.firstWhere((element) => ExpressionMapping.expressionToColor(element) != null);
+          List<css.LiteralTerm?>? potentialStyles = value.whereType<css.LiteralTerm>().toList();
+          /// Currently doesn't matter, as Flutter only supports "solid" or "none", but may support more in the future.
+          List<String> possibleBorderValues = ["dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset", "none", "hidden"];
+          /// List<css.LiteralTerm> might include other values than the ones we want for [BorderSide.style], so make sure to remove those before passing it to [ExpressionMapping]
+          potentialStyles.removeWhere((element) => element == null || !possibleBorderValues.contains(element.text));
+          css.LiteralTerm borderStyle = potentialStyles.first!;
+          Border newBorder = Border(
+            left: style.border?.left ?? BorderSide.none,
+            right: style.border?.right ?? BorderSide.none,
+            top: style.border?.top.copyWith(
+              width: ExpressionMapping.expressionToBorderWidth(borderWidth),
+              style: ExpressionMapping.expressionToBorderStyle(borderStyle),
+              color: ExpressionMapping.expressionToColor(borderColor),
+            ) ?? BorderSide(
+              width: ExpressionMapping.expressionToBorderWidth(borderWidth),
+              style: ExpressionMapping.expressionToBorderStyle(borderStyle),
+              color: ExpressionMapping.expressionToColor(borderColor) ?? Colors.black,
+            ),
+            bottom: style.border?.bottom ?? BorderSide.none,
+          );
+          style.border = newBorder;
+          break;
+        case 'border-bottom':
+          List<css.LiteralTerm?>? borderWidths = value.whereType<css.LiteralTerm>().toList();
+          /// List<css.LiteralTerm> might include other values than the ones we want for [BorderSide.width], so make sure to remove those before passing it to [ExpressionMapping]
+          borderWidths.removeWhere((element) => element == null || (element.text != "thin"
+              && element.text != "medium" && element.text != "thick"
+              && !(element is css.LengthTerm) && !(element is css.PercentageTerm)
+              && !(element is css.EmTerm) && !(element is css.RemTerm)
+              && !(element is css.NumberTerm))
+          );
+          css.LiteralTerm borderWidth = borderWidths.firstWhere((element) => element != null)!;
+          css.Expression borderColor = value.firstWhere((element) => ExpressionMapping.expressionToColor(element) != null);
+          List<css.LiteralTerm?>? potentialStyles = value.whereType<css.LiteralTerm>().toList();
+          /// Currently doesn't matter, as Flutter only supports "solid" or "none", but may support more in the future.
+          List<String> possibleBorderValues = ["dotted", "dashed", "solid", "double", "groove", "ridge", "inset", "outset", "none", "hidden"];
+          /// List<css.LiteralTerm> might include other values than the ones we want for [BorderSide.style], so make sure to remove those before passing it to [ExpressionMapping]
+          potentialStyles.removeWhere((element) => element == null || !possibleBorderValues.contains(element.text));
+          css.LiteralTerm borderStyle = potentialStyles.first!;
+          Border newBorder = Border(
+            left: style.border?.left ?? BorderSide.none,
+            right: style.border?.right ?? BorderSide.none,
+            top: style.border?.top ?? BorderSide.none,
+            bottom: style.border?.bottom.copyWith(
+              width: ExpressionMapping.expressionToBorderWidth(borderWidth),
+              style: ExpressionMapping.expressionToBorderStyle(borderStyle),
+              color: ExpressionMapping.expressionToColor(borderColor),
+            ) ?? BorderSide(
+              width: ExpressionMapping.expressionToBorderWidth(borderWidth),
+              style: ExpressionMapping.expressionToBorderStyle(borderStyle),
+              color: ExpressionMapping.expressionToColor(borderColor) ?? Colors.black,
+            ),
+          );
+          style.border = newBorder;
           break;
         case 'color':
           style.color = ExpressionMapping.expressionToColor(value.first) ?? style.color;
@@ -60,14 +192,78 @@ Style declarationsToStyle(Map<String?, List<css.Expression>> declarations) {
         case 'font-weight':
           style.fontWeight = ExpressionMapping.expressionToFontWeight(value.first);
           break;
+        case 'margin':
+          List<css.LiteralTerm>? marginLengths = value.whereType<css.LiteralTerm>().toList();
+          /// List<css.LiteralTerm> might include other values than the ones we want for margin length, so make sure to remove those before passing it to [ExpressionMapping]
+          marginLengths.removeWhere((element) => !(element is css.LengthTerm)
+              && !(element is css.EmTerm)
+              && !(element is css.RemTerm)
+              && !(element is css.NumberTerm)
+          );
+          List<double?> margin = ExpressionMapping.expressionToPadding(marginLengths);
+          style.margin = (style.margin ?? EdgeInsets.zero).copyWith(
+            left: margin[0],
+            right: margin[1],
+            top: margin[2],
+            bottom: margin[3],
+          );
+          break;
+        case 'margin-left':
+          style.margin = (style.margin ?? EdgeInsets.zero).copyWith(
+              left: ExpressionMapping.expressionToPaddingLength(value.first));
+          break;
+        case 'margin-right':
+          style.margin = (style.margin ?? EdgeInsets.zero).copyWith(
+              right: ExpressionMapping.expressionToPaddingLength(value.first));
+          break;
+        case 'margin-top':
+          style.margin = (style.margin ?? EdgeInsets.zero).copyWith(
+              top: ExpressionMapping.expressionToPaddingLength(value.first));
+          break;
+        case 'margin-bottom':
+          style.margin = (style.margin ?? EdgeInsets.zero).copyWith(
+              bottom: ExpressionMapping.expressionToPaddingLength(value.first));
+          break;
+        case 'padding':
+          List<css.LiteralTerm>? paddingLengths = value.whereType<css.LiteralTerm>().toList();
+          /// List<css.LiteralTerm> might include other values than the ones we want for padding length, so make sure to remove those before passing it to [ExpressionMapping]
+          paddingLengths.removeWhere((element) => !(element is css.LengthTerm)
+              && !(element is css.EmTerm)
+              && !(element is css.RemTerm)
+              && !(element is css.NumberTerm)
+          );
+          List<double?> padding = ExpressionMapping.expressionToPadding(paddingLengths);
+          style.padding = (style.padding ?? EdgeInsets.zero).copyWith(
+            left: padding[0],
+            right: padding[1],
+            top: padding[2],
+            bottom: padding[3],
+          );
+          break;
+        case 'padding-left':
+          style.padding = (style.padding ?? EdgeInsets.zero).copyWith(
+              left: ExpressionMapping.expressionToPaddingLength(value.first));
+          break;
+        case 'padding-right':
+          style.padding = (style.padding ?? EdgeInsets.zero).copyWith(
+              right: ExpressionMapping.expressionToPaddingLength(value.first));
+          break;
+        case 'padding-top':
+          style.padding = (style.padding ?? EdgeInsets.zero).copyWith(
+              top: ExpressionMapping.expressionToPaddingLength(value.first));
+          break;
+        case 'padding-bottom':
+          style.padding = (style.padding ?? EdgeInsets.zero).copyWith(
+              bottom: ExpressionMapping.expressionToPaddingLength(value.first));
+          break;
         case 'text-align':
           style.textAlign = ExpressionMapping.expressionToTextAlign(value.first);
           break;
         case 'text-decoration':
           List<css.LiteralTerm?>? textDecorationList = value.whereType<css.LiteralTerm>().toList();
           /// List<css.LiteralTerm> might include other values than the ones we want for [textDecorationList], so make sure to remove those before passing it to [ExpressionMapping]
-          textDecorationList.removeWhere((element) => element != null && element.text != "none"
-              && element.text != "overline" && element.text != "underline" && element.text != "line-through");
+          textDecorationList.removeWhere((element) => element == null || (element.text != "none"
+              && element.text != "overline" && element.text != "underline" && element.text != "line-through"));
           List<css.Expression?>? nullableList = value;
           css.Expression? textDecorationColor;
           /// orElse: will not allow me to return null (even if the compiler says its okay, it errors on runtime).
@@ -80,8 +276,8 @@ Style declarationsToStyle(Map<String?, List<css.Expression>> declarations) {
           }
           List<css.LiteralTerm?>? potentialStyles = value.whereType<css.LiteralTerm>().toList();
           /// List<css.LiteralTerm> might include other values than the ones we want for [textDecorationStyle], so make sure to remove those before passing it to [ExpressionMapping]
-          potentialStyles.removeWhere((element) => element != null && element.text != "solid"
-              && element.text != "double" && element.text != "dashed" && element.text != "dotted" && element.text != "wavy");
+          potentialStyles.removeWhere((element) => element == null || (element.text != "solid"
+              && element.text != "double" && element.text != "dashed" && element.text != "dotted" && element.text != "wavy"));
           css.LiteralTerm? textDecorationStyle = potentialStyles.isNotEmpty ? potentialStyles.last : null;
           style.textDecoration = ExpressionMapping.expressionToTextDecorationLine(textDecorationList);
           if (textDecorationColor != null) style.textDecorationColor = ExpressionMapping.expressionToColor(textDecorationColor)
@@ -422,6 +618,50 @@ class ExpressionMapping {
       return LineHeight(double.tryParse(value.text.replaceAll(new RegExp(r'\s+(\d+\.\d+)\s+'), '')), units: "length");
     }
     return LineHeight.normal;
+  }
+
+  static List<double?> expressionToPadding(List<css.Expression>? lengths) {
+    double? left;
+    double? right;
+    double? top;
+    double? bottom;
+    if (lengths != null && lengths.isNotEmpty) {
+      top = expressionToPaddingLength(lengths.first);
+      if (lengths.length == 4) {
+        right = expressionToPaddingLength(lengths[1]);
+        bottom = expressionToPaddingLength(lengths[2]);
+        left = expressionToPaddingLength(lengths.last);
+      }
+      if (lengths.length == 3) {
+        left = expressionToPaddingLength(lengths[1]);
+        right = expressionToPaddingLength(lengths[1]);
+        bottom = expressionToPaddingLength(lengths.last);
+      }
+      if (lengths.length == 2) {
+        bottom = expressionToPaddingLength(lengths.first);
+        left = expressionToPaddingLength(lengths.last);
+        right = expressionToPaddingLength(lengths.last);
+      }
+      if (lengths.length == 1) {
+        bottom = expressionToPaddingLength(lengths.first);
+        left = expressionToPaddingLength(lengths.first);
+        right = expressionToPaddingLength(lengths.first);
+      }
+    }
+    return [left, right, top, bottom];
+  }
+
+  static double? expressionToPaddingLength(css.Expression value) {
+    if (value is css.NumberTerm) {
+      return double.tryParse(value.text);
+    } else if (value is css.EmTerm) {
+      return double.tryParse(value.text);
+    } else if (value is css.RemTerm) {
+      return double.tryParse(value.text);
+    } else if (value is css.LengthTerm) {
+      return double.tryParse(value.text.replaceAll(new RegExp(r'\s+(\d+\.\d+)\s+'), ''));
+    }
+    return null;
   }
 
   static TextAlign expressionToTextAlign(css.Expression value) {


### PR DESCRIPTION
Fixes #605
Fixes #469

Adds support for border-bottom/left/right/top, margin, margin-bottom/left/right/top, padding, padding-bottom/left/right/top
Fixes some bugs with inline styles when using `removeWhere()`

One thing I would like some clarification on is whether we should use `copyWith` or directly overwrite the currently applied style. `copyWith` would take the set style from the `Style()` constructor.