### PR TITLE
Fix empty space when there are empty block elements in the HTML

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -278,7 +278,7 @@ class HtmlParser extends StatelessWidget {
     }
 
     //Return the correct InlineSpan based on the element type.
-    if (tree.style.display == Display.BLOCK) {
+    if (tree.style.display == Display.BLOCK && tree.children.isNotEmpty) {
       return WidgetSpan(
         child: ContainerSpan(
           key: AnchorKey.of(key, tree),


### PR DESCRIPTION
Fixes #643

I don't know if there are any regressions with this change but I doubt it.