### PR TITLE
Fix Bad State error when setting a ul to have an ol list type

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -553,6 +553,9 @@ class HtmlParser extends StatelessWidget {
           tree.style.markerContent = '•';
           break;
         case ListStyleType.DECIMAL:
+          if (olStack.isEmpty) {
+            olStack.add(Context((tree.attributes['start'] != null ? int.tryParse(tree.attributes['start'] ?? "") ?? 1 : 1) - 1));
+          }
           olStack.last.data += 1;
           tree.style.markerContent = '${olStack.last.data}.';
           break;


### PR DESCRIPTION
Fixes #651

This error only happens when setting a `ul` (unordered) to have an `ol` marker. There wasn't an `olStack` created before to keep track of the markers, so `olStack.last` throws an exception.