### PR TITLE
Fix Stack Overflow error when using before and afters

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -572,16 +572,17 @@ class HtmlParser extends StatelessWidget {
   /// the list of the trees children according to the `before` and `after` Style
   /// properties.
   static StyledElement _processBeforesAndAfters(StyledElement tree) {
-    if (tree.style.before != null) {
+    if (tree.style.before != null && tree.children.isNotEmpty) {
       tree.children.insert(
-          0, TextContentElement(text: tree.style.before, style: tree.style));
+          0, new TextContentElement(text: tree.style.before, style: tree.style.copyWith(beforeAfterNull: true, display: Display.INLINE)));
     }
     if (tree.style.after != null) {
       tree.children
-          .add(TextContentElement(text: tree.style.after, style: tree.style));
-    } else {
-      tree.children.forEach(_processBeforesAndAfters);
+          .add(TextContentElement(text: tree.style.after, style: tree.style.copyWith(beforeAfterNull: true, display: Display.INLINE)));
     }
+
+    tree.children.forEach(_processBeforesAndAfters);
+
     return tree;
   }
 

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -572,9 +572,9 @@ class HtmlParser extends StatelessWidget {
   /// the list of the trees children according to the `before` and `after` Style
   /// properties.
   static StyledElement _processBeforesAndAfters(StyledElement tree) {
-    if (tree.style.before != null && tree.children.isNotEmpty) {
+    if (tree.style.before != null) {
       tree.children.insert(
-          0, new TextContentElement(text: tree.style.before, style: tree.style.copyWith(beforeAfterNull: true, display: Display.INLINE)));
+          0, TextContentElement(text: tree.style.before, style: tree.style.copyWith(beforeAfterNull: true, display: Display.INLINE)));
     }
     if (tree.style.after != null) {
       tree.children

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -348,6 +348,7 @@ class Style {
     Border? border,
     Alignment? alignment,
     String? markerContent,
+    bool? beforeAfterNull,
   }) {
     return Style(
       backgroundColor: backgroundColor ?? this.backgroundColor,
@@ -377,8 +378,8 @@ class Style {
       whiteSpace: whiteSpace ?? this.whiteSpace,
       width: width ?? this.width,
       wordSpacing: wordSpacing ?? this.wordSpacing,
-      before: before ?? this.before,
-      after: after ?? this.after,
+      before: beforeAfterNull == true ? null : before ?? this.before,
+      after: beforeAfterNull == true ? null : after ?? this.after,
       border: border ?? this.border,
       alignment: alignment ?? this.alignment,
       markerContent: markerContent ?? this.markerContent,


### PR DESCRIPTION
Fixes #650

The style for the before/after kept getting cascaded to the before/after child so it was basically an infinite loop. Now the before/after is not cascaded (the rest of the parent style is applied though).