### PR TITLE
Add support for more list style types & detect list style type from inline style

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -100,9 +100,11 @@ const htmlData = r"""
             <li>a</li>
             <li>nested</li>
             <li>unordered
-            <ol>
+            <ol style="list-style-type: lower-alpha;" start="5">
             <li>With a nested</li>
-            <li>ordered list.</li>
+            <li>ordered list</li>
+            <li>with a lower alpha list style</li>
+            <li>starting at letter e</li>
             </ol>
             </li>
             <li>list</li>

--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -61,6 +61,11 @@ Style declarationsToStyle(Map<String?, List<css.Expression>> declarations) {
         case 'font-weight':
           style.fontWeight = ExpressionMapping.expressionToFontWeight(value.first);
           break;
+        case 'list-style-type':
+          if (value.first is css.LiteralTerm) {
+            style.listStyleType = ExpressionMapping.expressionToListStyleType(value.first as css.LiteralTerm) ?? style.listStyleType;
+          }
+          break;
         case 'text-align':
           style.textAlign = ExpressionMapping.expressionToTextAlign(value.first);
           break;
@@ -417,6 +422,32 @@ class ExpressionMapping {
       return LineHeight(double.tryParse(value.text.replaceAll(new RegExp(r'\s+(\d+\.\d+)\s+'), '')), units: "length");
     }
     return LineHeight.normal;
+  }
+
+  static ListStyleType? expressionToListStyleType(css.LiteralTerm value) {
+    switch (value.text) {
+      case 'disc':
+        return ListStyleType.DISC;
+      case 'circle':
+        return ListStyleType.CIRCLE;
+      case 'decimal':
+        return ListStyleType.DECIMAL;
+      case 'lower-alpha':
+        return ListStyleType.LOWER_ALPHA;
+      case 'lower-latin':
+        return ListStyleType.LOWER_LATIN;
+      case 'lower-roman':
+        return ListStyleType.LOWER_ROMAN;
+      case 'square':
+        return ListStyleType.SQUARE;
+      case 'upper-alpha':
+        return ListStyleType.UPPER_ALPHA;
+      case 'upper-latin':
+        return ListStyleType.UPPER_LATIN;
+      case 'upper-roman':
+        return ListStyleType.UPPER_ROMAN;
+    }
+    return null;
   }
 
   static TextAlign expressionToTextAlign(css.Expression value) {

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -474,8 +474,16 @@ class LineHeight {
 }
 
 enum ListStyleType {
+  LOWER_ALPHA,
+  UPPER_ALPHA,
+  LOWER_LATIN,
+  UPPER_LATIN,
+  CIRCLE,
   DISC,
   DECIMAL,
+  LOWER_ROMAN,
+  UPPER_ROMAN,
+  SQUARE,
 }
 
 enum ListStylePosition {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,9 @@ dependencies:
   # plugin for firstWhereOrNull extension on lists
   collection: '>=1.15.0 <2.0.0'
 
+  # plugin to convert integers to numerals
+  numerus: '>=1.1.1 <2.0.0'
+
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Adds lower/upper roman, latin, and alpha, along with circle/square list style types.

Adds support for getting list style type from inline CSS when present.

Lower/upper roman, latin, and alpha support the `start` attribute.

Fixes #704.