### PR TITLE
Add support for the style tag

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -295,6 +295,13 @@ class _MyHomePageState extends State<MyHomePage> {
           onImageError: (exception, stackTrace) {
             print(exception);
           },
+          onCSSParseError: (css, messages) {
+            print("css that errored: $css");
+            print("error messages:");
+            messages.forEach((element) {
+              print(element);
+            });
+          },
         ),
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -303,7 +303,7 @@ class _MyHomePageState extends State<MyHomePage> {
           onImageError: (exception, stackTrace) {
             print(exception);
           },
-          onCSSParseError: (css, messages) {
+          onCssParseError: (css, messages) {
             print("css that errored: $css");
             print("error messages:");
             messages.forEach((element) {

--- a/lib/flutter_html.dart
+++ b/lib/flutter_html.dart
@@ -53,6 +53,7 @@ class Html extends StatelessWidget {
     this.onLinkTap,
     this.customRender = const {},
     this.customImageRenders = const {},
+    this.onCSSParseError,
     this.onImageError,
     this.onMathError,
     this.shrinkWrap = false,
@@ -71,6 +72,7 @@ class Html extends StatelessWidget {
     this.onLinkTap,
     this.customRender = const {},
     this.customImageRenders = const {},
+    this.onCSSParseError,
     this.onImageError,
     this.onMathError,
     this.shrinkWrap = false,
@@ -98,6 +100,9 @@ class Html extends StatelessWidget {
   /// An API that allows you to customize the entire process of image rendering.
   /// See the README for more details.
   final Map<ImageSourceMatcher, ImageRender> customImageRenders;
+
+  /// A function that defines what to do when CSS fails to parse
+  final OnCSSParseError? onCSSParseError;
 
   /// A function that defines what to do when an image errors
   final ImageErrorListener? onImageError;
@@ -148,6 +153,7 @@ class Html extends StatelessWidget {
         htmlData: doc,
         onLinkTap: onLinkTap,
         onImageTap: onImageTap,
+        onCSSParseError: onCSSParseError,
         onImageError: onImageError,
         onMathError: onMathError,
         shrinkWrap: shrinkWrap,

--- a/lib/flutter_html.dart
+++ b/lib/flutter_html.dart
@@ -53,7 +53,7 @@ class Html extends StatelessWidget {
     this.onLinkTap,
     this.customRender = const {},
     this.customImageRenders = const {},
-    this.onCSSParseError,
+    this.onCssParseError,
     this.onImageError,
     this.onMathError,
     this.shrinkWrap = false,
@@ -72,7 +72,7 @@ class Html extends StatelessWidget {
     this.onLinkTap,
     this.customRender = const {},
     this.customImageRenders = const {},
-    this.onCSSParseError,
+    this.onCssParseError,
     this.onImageError,
     this.onMathError,
     this.shrinkWrap = false,
@@ -102,7 +102,7 @@ class Html extends StatelessWidget {
   final Map<ImageSourceMatcher, ImageRender> customImageRenders;
 
   /// A function that defines what to do when CSS fails to parse
-  final OnCSSParseError? onCSSParseError;
+  final OnCssParseError? onCssParseError;
 
   /// A function that defines what to do when an image errors
   final ImageErrorListener? onImageError;
@@ -153,7 +153,7 @@ class Html extends StatelessWidget {
         htmlData: doc,
         onLinkTap: onLinkTap,
         onImageTap: onImageTap,
-        onCSSParseError: onCSSParseError,
+        onCssParseError: onCssParseError,
         onImageError: onImageError,
         onMathError: onMathError,
         shrinkWrap: shrinkWrap,

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -742,7 +742,7 @@ class HtmlParser extends StatelessWidget {
     tree.children.forEach((child) {
       if (child is EmptyContentElement || child is EmptyLayoutElement) {
         toRemove.add(child);
-      } else if (child is TextContentElement && (child.text!.isEmpty)) {
+      } else if (child is TextContentElement && (child.text!.trim().isEmpty)) {
         toRemove.add(child);
       } else if (child is TextContentElement &&
           child.style.whiteSpace != WhiteSpace.PRE &&

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -28,7 +28,7 @@ typedef OnMathError = Widget Function(
     String exception,
     String exceptionWithType,
 );
-typedef OnCSSParseError = String? Function(
+typedef OnCssParseError = String? Function(
   String css,
   List<cssparser.Message> errors,
 );
@@ -42,7 +42,7 @@ class HtmlParser extends StatelessWidget {
   final dom.Document htmlData;
   final OnTap? onLinkTap;
   final OnTap? onImageTap;
-  final OnCSSParseError? onCSSParseError;
+  final OnCssParseError? onCssParseError;
   final ImageErrorListener? onImageError;
   final OnMathError? onMathError;
   final bool shrinkWrap;
@@ -59,7 +59,7 @@ class HtmlParser extends StatelessWidget {
     required this.htmlData,
     required this.onLinkTap,
     required this.onImageTap,
-    required this.onCSSParseError,
+    required this.onCssParseError,
     required this.onImageError,
     required this.onMathError,
     required this.shrinkWrap,
@@ -72,18 +72,18 @@ class HtmlParser extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    Map<String, Map<String, List<css.Expression>>> declarations = _getExternalCSSDeclarations(htmlData.getElementsByTagName("style"), onCSSParseError);
+    Map<String, Map<String, List<css.Expression>>> declarations = _getExternalCssDeclarations(htmlData.getElementsByTagName("style"), onCssParseError);
     StyledElement lexedTree = lexDomTree(
       htmlData,
       customRender.keys.toList(),
       tagsList,
       navigationDelegateForIframe,
     );
-    StyledElement? externalCSSStyledTree;
+    StyledElement? externalCssStyledTree;
     if (declarations.isNotEmpty) {
-      externalCSSStyledTree = _applyExternalCSS(declarations, lexedTree);
+      externalCssStyledTree = _applyExternalCss(declarations, lexedTree);
     }
-    StyledElement inlineStyledTree = _applyInlineStyles(externalCSSStyledTree ?? lexedTree, onCSSParseError);
+    StyledElement inlineStyledTree = _applyInlineStyles(externalCssStyledTree ?? lexedTree, onCssParseError);
     StyledElement customStyledTree = _applyCustomStyles(style, inlineStyledTree);
     StyledElement cascadedStyledTree = _cascadeStyles(style, customStyledTree);
     StyledElement cleanedTree = cleanTree(cascadedStyledTree);
@@ -119,8 +119,8 @@ class HtmlParser extends StatelessWidget {
     return htmlparser.parse(data);
   }
 
-  /// [parseCSS] converts a string of CSS to a CSS stylesheet using the dart `csslib` library.
-  static css.StyleSheet parseCSS(String data) {
+  /// [parseCss] converts a string of CSS to a CSS stylesheet using the dart `csslib` library.
+  static css.StyleSheet parseCss(String data) {
     return cssparser.parse(data);
   }
 
@@ -200,34 +200,34 @@ class HtmlParser extends StatelessWidget {
     }
   }
 
-  static Map<String, Map<String, List<css.Expression>>> _getExternalCSSDeclarations(List<dom.Element> styles, OnCSSParseError? errorHandler) {
-    String fullCSS = "";
+  static Map<String, Map<String, List<css.Expression>>> _getExternalCssDeclarations(List<dom.Element> styles, OnCssParseError? errorHandler) {
+    String fullCss = "";
     for (final e in styles) {
-      fullCSS = fullCSS + e.innerHtml;
+      fullCss = fullCss + e.innerHtml;
     }
-    if (fullCSS.isNotEmpty) {
-      final declarations = parseExternalCSS(fullCSS, errorHandler);
+    if (fullCss.isNotEmpty) {
+      final declarations = parseExternalCss(fullCss, errorHandler);
       return declarations;
     } else {
       return {};
     }
   }
 
-  static StyledElement _applyExternalCSS(Map<String, Map<String, List<css.Expression>>> declarations, StyledElement tree) {
+  static StyledElement _applyExternalCss(Map<String, Map<String, List<css.Expression>>> declarations, StyledElement tree) {
     declarations.forEach((key, style) {
       if (tree.matchesSelector(key)) {
         tree.style = tree.style.merge(declarationsToStyle(style));
       }
     });
 
-    tree.children.forEach((e) => _applyExternalCSS(declarations, e));
+    tree.children.forEach((e) => _applyExternalCss(declarations, e));
 
     return tree;
   }
 
-  static StyledElement _applyInlineStyles(StyledElement tree, OnCSSParseError? errorHandler) {
+  static StyledElement _applyInlineStyles(StyledElement tree, OnCssParseError? errorHandler) {
     if (tree.attributes.containsKey("style")) {
-      final newStyle = inlineCSSToStyle(tree.attributes['style'], errorHandler);
+      final newStyle = inlineCssToStyle(tree.attributes['style'], errorHandler);
       if (newStyle != null) {
         tree.style = tree.style.merge(newStyle);
       }

--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -150,9 +150,7 @@ class DeclarationVisitor extends css.Visitor {
 
   @override
   void visitExpressions(css.Expressions node) {
-    node.expressions.forEach((expression) {
-      _properties[_currentProperty]!.add(expression);
-    });
+    _properties[_currentProperty]!.addAll(node.expressions);
   }
 }
 

--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -103,30 +103,30 @@ Style declarationsToStyle(Map<String, List<css.Expression>> declarations) {
   return style;
 }
 
-Style? inlineCSSToStyle(String? inlineStyle, OnCSSParseError? errorHandler) {
+Style? inlineCssToStyle(String? inlineStyle, OnCssParseError? errorHandler) {
   var errors = <cssparser.Message>[];
   final sheet = cssparser.parse("*{$inlineStyle}", errors: errors);
   if (errors.isEmpty) {
     final declarations = DeclarationVisitor().getDeclarations(sheet);
     return declarationsToStyle(declarations["*"]!);
   } else if (errorHandler != null) {
-    String? newCSS = errorHandler.call(inlineStyle ?? "", errors);
-    if (newCSS != null) {
-      return inlineCSSToStyle(newCSS, errorHandler);
+    String? newCss = errorHandler.call(inlineStyle ?? "", errors);
+    if (newCss != null) {
+      return inlineCssToStyle(newCss, errorHandler);
     }
   }
   return null;
 }
 
-Map<String, Map<String, List<css.Expression>>> parseExternalCSS(String css, OnCSSParseError? errorHandler) {
+Map<String, Map<String, List<css.Expression>>> parseExternalCss(String css, OnCssParseError? errorHandler) {
   var errors = <cssparser.Message>[];
   final sheet = cssparser.parse(css, errors: errors);
   if (errors.isEmpty) {
     return DeclarationVisitor().getDeclarations(sheet);
   } else if (errorHandler != null) {
-    String? newCSS = errorHandler.call(css, errors);
-    if (newCSS != null) {
-      return parseExternalCSS(newCSS, errorHandler);
+    String? newCss = errorHandler.call(css, errors);
+    if (newCss != null) {
+      return parseExternalCss(newCss, errorHandler);
     }
   }
   return {};

--- a/lib/src/html_elements.dart
+++ b/lib/src/html_elements.dart
@@ -77,7 +77,6 @@ const INTERACTABLE_ELEMENTS = [
 const REPLACED_ELEMENTS = [
   "audio",
   "br",
-  "head",
   "iframe",
   "img",
   "svg",

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -242,8 +242,8 @@ class Style {
     'body': Style.fromTextStyle(theme.textTheme.bodyText2!),
   };
 
-  static Map<String, Style> fromCSS(String css, OnCSSParseError? onCSSParseError) {
-    final declarations = parseExternalCSS(css, onCSSParseError);
+  static Map<String, Style> fromCss(String css, OnCssParseError? onCssParseError) {
+    final declarations = parseExternalCss(css, onCssParseError);
     Map<String, Style> styleMap = {};
     declarations.forEach((key, value) {
       styleMap[key] = declarationsToStyle(value);

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_html/src/css_parser.dart';
 
 ///This class represents all the available CSS attributes
@@ -215,8 +216,8 @@ class Style {
     }
   }
 
-  static Map<String, Style> fromCSS(String css) {
-    final declarations = parseExternalCSS(css);
+  static Map<String, Style> fromCSS(String css, OnCSSParseError? onCSSParseError) {
+    final declarations = parseExternalCSS(css, onCSSParseError);
     Map<String, Style> styleMap = {};
     declarations.forEach((key, value) {
       styleMap[key] = declarationsToStyle(value);

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_html/src/css_parser.dart';
 
 ///This class represents all the available CSS attributes
 ///for this package.
@@ -212,6 +213,15 @@ class Style {
         (display == Display.BLOCK || display == Display.LIST_ITEM)) {
       this.alignment = Alignment.centerLeft;
     }
+  }
+
+  static Map<String, Style> fromCSS(String css) {
+    final declarations = parseExternalCSS(css);
+    Map<String, Style> styleMap = {};
+    declarations.forEach((key, value) {
+      styleMap[key] = declarationsToStyle(value);
+    });
+    return styleMap;
   }
 
   TextStyle generateTextStyle() {


### PR DESCRIPTION
Fixes #593 and sort of addresses #207 (we still don't support all the styles given in the example in that issue).

![image](https://user-images.githubusercontent.com/50850142/116828280-aef3dd80-ab6b-11eb-84a8-5671120783d0.png)


<details><summary> Test HTML </summary>

```html
<html>
<head>
<style>
body {
  background-color: lightblue;
}
</style>
<style>
h1 {
  color: white;
  text-align: center;
}
</style>
<style>
p {
  font-size: 20px;
}
</style>
</head>
<body>

<h1>My First CSS Example</h1>
<p style="color: blue;">This is a paragraph.</p>

</body>
</html>
```

</details>

~~Should we add a parameter to the `Html` widget to allow users to pass the external CSS as a string separate from the HTML data? Don't know if that would be useful but it wouldn't be difficult to implement at all.~~ Done via `Style.fromCSS` function.

 ~~Also for some reason adding `<head>` to the document adds a space at the top of the doc, I don't know if the changes made in #646 will help that but I don't think so.~~ Fixed