### PR TITLE
Add getFromThemeData method to Style

### DIFF
--- a/lib/style.dart
+++ b/lib/style.dart
@@ -214,6 +214,16 @@ class Style {
     }
   }
 
+  static Map<String, Style> getFromThemeData(ThemeData theme) => {
+    'h1': Style.fromTextStyle(theme.textTheme.headline1!),
+    'h2': Style.fromTextStyle(theme.textTheme.headline2!),
+    'h3': Style.fromTextStyle(theme.textTheme.headline3!),
+    'h4': Style.fromTextStyle(theme.textTheme.headline4!),
+    'h5': Style.fromTextStyle(theme.textTheme.headline5!),
+    'h6': Style.fromTextStyle(theme.textTheme.headline6!),
+    'body': Style.fromTextStyle(theme.textTheme.bodyText2!),
+  };
+
   TextStyle generateTextStyle() {
     return TextStyle(
       backgroundColor: backgroundColor,

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -214,7 +214,7 @@ class Style {
     }
   }
 
-  static Map<String, Style> getFromThemeData(ThemeData theme) => {
+  static Map<String, Style> fromThemeData(ThemeData theme) => {
     'h1': Style.fromTextStyle(theme.textTheme.headline1!),
     'h2': Style.fromTextStyle(theme.textTheme.headline2!),
     'h3': Style.fromTextStyle(theme.textTheme.headline3!),


### PR DESCRIPTION
Fixes #303

Users can do 

```dart
Html(
   style: Style.getFromThemeData(ThemeData.of(context))..addAll(/*other styles*/),
),
```

To make `h1`-`h6` and other text elements behave more in line with Flutter styles rather than CSS styles.