### PR TITLE
Fix shrinkWrap to shrinkwrap most elements

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -929,7 +929,6 @@ class StyledText extends StatelessWidget {
       return double.infinity;
     }
     if ((style.display == Display.BLOCK || style.display == Display.LIST_ITEM) && !renderContext.parser.shrinkWrap) {
-      print(renderContext.tree.element?.localName);
       return double.infinity;
     }
     if (!renderContext.parser.shrinkWrap && renderContext.tree.element?.localName == "html") {

--- a/lib/src/replaced_element.dart
+++ b/lib/src/replaced_element.dart
@@ -283,13 +283,13 @@ class MathElement extends ReplacedElement {
     required this.element,
     this.texStr,
     String name = "math",
-  }) : super(name: name, alignment: PlaceholderAlignment.middle, style: Style(), elementId: element.id);
+  }) : super(name: name, alignment: PlaceholderAlignment.middle, style: Style(display: Display.BLOCK), elementId: element.id);
 
   @override
   Widget toWidget(RenderContext context) {
     texStr = parseMathRecursive(element, r'');
     return Container(
-      width: MediaQuery.of(context.buildContext).size.width,
+      width: context.parser.shrinkWrap ? null : MediaQuery.of(context.buildContext).size.width,
       child: Math.tex(
         texStr ?? '',
         mathStyle: MathStyle.display,


### PR DESCRIPTION
Title.

Builds on #675.

Fixes #671 and fixes #565.

`shrinkWrap: true` and `'html': Style(backgroundColor: Colors.yellow),` in `Style()`:

(Some elements were removed, see below)

<img width="250px" src="https://user-images.githubusercontent.com/50850142/118378882-ac9a7600-b5a4-11eb-9af4-46771c7d2e26.png"/>

## Limitations

It will not shrinkwrap:
* table
* ul
* ol
* any element with a custom `TextAlign` because the full width is needed to represent those correctly, e.g. `TextAlign.center`

Regression testing needed, I don't think there are any. If there are it'll be with layout - there shouldn't be any errors in code.