### PR TITLE
Add strictMode param for strict checking of IDs in HTML

### DIFF
--- a/lib/flutter_html.dart
+++ b/lib/flutter_html.dart
@@ -56,6 +56,7 @@ class Html extends StatelessWidget {
     this.onCssParseError,
     this.onImageError,
     this.onMathError,
+    this.strictMode = false,
     this.shrinkWrap = false,
     this.onImageTap,
     this.tagsList = const [],
@@ -75,6 +76,7 @@ class Html extends StatelessWidget {
     this.onCssParseError,
     this.onImageError,
     this.onMathError,
+    this.strictMode = false,
     this.shrinkWrap = false,
     this.onImageTap,
     this.tagsList = const [],
@@ -111,6 +113,8 @@ class Html extends StatelessWidget {
   /// You can return a widget here to override the default error widget.
   final OnMathError? onMathError;
 
+  /// When true, an exception will be thrown if two elements have the same ID
+  final bool strictMode;
 
   /// A parameter that should be set when the HTML widget is expected to be
   /// flexible
@@ -156,6 +160,7 @@ class Html extends StatelessWidget {
         onCssParseError: onCssParseError,
         onImageError: onImageError,
         onMathError: onMathError,
+        strictMode: strictMode,
         shrinkWrap: shrinkWrap,
         style: style,
         customRender: customRender,
@@ -164,6 +169,7 @@ class Html extends StatelessWidget {
           ..addAll(defaultImageRenders),
         tagsList: tagsList.isEmpty ? Html.tags : tagsList,
         navigationDelegateForIframe: navigationDelegateForIframe,
+        anchors: [],
       ),
     );
   }

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -45,6 +45,7 @@ class HtmlParser extends StatelessWidget {
   final OnCssParseError? onCssParseError;
   final ImageErrorListener? onImageError;
   final OnMathError? onMathError;
+  final bool strictMode;
   final bool shrinkWrap;
 
   final Map<String, Style> style;
@@ -54,6 +55,8 @@ class HtmlParser extends StatelessWidget {
   final NavigationDelegate? navigationDelegateForIframe;
   final OnTap? _onAnchorTap;
 
+  final List<String> anchors;
+
   HtmlParser({
     required this.key,
     required this.htmlData,
@@ -62,13 +65,15 @@ class HtmlParser extends StatelessWidget {
     required this.onCssParseError,
     required this.onImageError,
     required this.onMathError,
+    required this.strictMode,
     required this.shrinkWrap,
     required this.style,
     required this.customRender,
     required this.imageRenders,
     required this.tagsList,
     required this.navigationDelegateForIframe,
-  }): this._onAnchorTap = key != null ? _handleAnchorTap(key, onLinkTap): null, super(key: key);
+    required this.anchors,
+  }): this._onAnchorTap = key != null ? _handleAnchorTap(key, onLinkTap, anchors): null, super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -293,7 +298,7 @@ class HtmlParser extends StatelessWidget {
       final render = customRender[tree.name]!.call(
         newContext,
         ContainerSpan(
-          key: AnchorKey.of(key, tree),
+          key: AnchorKey.of(key, tree, this),
           newContext: newContext,
           style: tree.style,
           shrinkWrap: context.parser.shrinkWrap,
@@ -306,7 +311,7 @@ class HtmlParser extends StatelessWidget {
             ? render
             : WidgetSpan(
                 child: ContainerSpan(
-                  key: AnchorKey.of(key, tree),
+                  key: AnchorKey.of(key, tree, this),
                   newContext: newContext,
                   style: tree.style,
                   shrinkWrap: context.parser.shrinkWrap,
@@ -320,7 +325,7 @@ class HtmlParser extends StatelessWidget {
     if (tree.style.display == Display.BLOCK) {
       return WidgetSpan(
         child: ContainerSpan(
-          key: AnchorKey.of(key, tree),
+          key: AnchorKey.of(key, tree, this),
           newContext: newContext,
           style: tree.style,
           shrinkWrap: context.parser.shrinkWrap,
@@ -339,7 +344,7 @@ class HtmlParser extends StatelessWidget {
 
       return WidgetSpan(
         child: ContainerSpan(
-          key: AnchorKey.of(key, tree),
+          key: AnchorKey.of(key, tree, this),
           newContext: newContext,
           style: tree.style,
           shrinkWrap: context.parser.shrinkWrap,
@@ -410,7 +415,7 @@ class HtmlParser extends StatelessWidget {
         } else {
           return WidgetSpan(
             child: RawGestureDetector(
-              key: AnchorKey.of(key, tree),
+              key: AnchorKey.of(key, tree, this),
               gestures: {
                 MultipleTapGestureRecognizer:
                     GestureRecognizerFactoryWithHandlers<
@@ -458,7 +463,7 @@ class HtmlParser extends StatelessWidget {
       //Requires special layout features not available in the TextStyle API.
       return WidgetSpan(
         child: Transform.translate(
-          key: AnchorKey.of(key, tree),
+          key: AnchorKey.of(key, tree, this),
           offset: Offset(0, verticalOffset),
           child: StyledText(
             textSpan: TextSpan(
@@ -482,10 +487,10 @@ class HtmlParser extends StatelessWidget {
     }
   }
 
-  static OnTap _handleAnchorTap(Key key, OnTap? onLinkTap) =>
+  static OnTap _handleAnchorTap(Key key, OnTap? onLinkTap, List<String> anchors) =>
           (String? url, RenderContext context, Map<String, String> attributes, dom.Element? element) {
         if (url?.startsWith("#") == true) {
-          final anchorContext = AnchorKey.forId(key, url!.substring(1))?.currentContext;
+          final anchorContext = AnchorKey.forId(key, url!.substring(1), anchors)?.currentContext;
           if (anchorContext != null) {
             Scrollable.ensureVisible(anchorContext);
           }

--- a/lib/src/anchor.dart
+++ b/lib/src/anchor.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_html/src/styled_element.dart';
 
 class AnchorKey extends GlobalKey {
@@ -8,14 +9,24 @@ class AnchorKey extends GlobalKey {
 
   const AnchorKey._(this.parentKey, this.id) : super.constructor();
 
-  static AnchorKey? of(Key? parentKey, StyledElement? id) {
-    return forId(parentKey, id?.elementId);
+  static AnchorKey? of(Key? parentKey, StyledElement? id, HtmlParser parser) {
+    if (parser.strictMode && parser.anchors.contains(id?.elementId)) {
+      throw Exception("Duplicate ID detected in HTML code. To prevent a "
+          "'Duplicate GlobalKey' error, please do one of the following: 1) "
+          "Correct the duplicate ID in the HTML to a unique ID or 2) Disable "
+          "strictMode, in which case the duplicate ID will be ignored.");
+    }
+    return forId(parentKey, id?.elementId, parser.anchors, checkKeys: true);
   }
 
-  static AnchorKey? forId(Key? parentKey, String? id) {
+  static AnchorKey? forId(Key? parentKey, String? id, List<String> anchors, {bool checkKeys = false}) {
+    if (checkKeys && anchors.contains(id)) {
+      return null;
+    }
     if (parentKey == null || id == null || id.isEmpty || id == "[[No ID]]") {
       return null;
     }
+    anchors.add(id);
     return AnchorKey._(parentKey, id);
   }
 

--- a/lib/src/layout_element.dart
+++ b/lib/src/layout_element.dart
@@ -32,7 +32,7 @@ class TableLayoutElement extends LayoutElement {
   @override
   Widget toWidget(RenderContext context) {
     return Container(
-      key: AnchorKey.of(context.parser.key, this),
+      key: AnchorKey.of(context.parser.key, this, context.parser),
       margin: style.margin,
       padding: style.padding,
       decoration: BoxDecoration(
@@ -282,7 +282,7 @@ class DetailsContentElement extends LayoutElement {
     }
     InlineSpan? firstChild = childrenList.isNotEmpty == true ? childrenList.first : null;
     return ExpansionTile(
-        key: AnchorKey.of(context.parser.key, this),
+        key: AnchorKey.of(context.parser.key, this, context.parser),
         expandedAlignment: Alignment.centerLeft,
         title: elementList.isNotEmpty == true && elementList.first.localName == "summary" ? StyledText(
           textSpan: TextSpan(

--- a/lib/src/replaced_element.dart
+++ b/lib/src/replaced_element.dart
@@ -84,7 +84,7 @@ class ImageContentElement extends ReplacedElement {
       if (entry.key.call(attributes, element)) {
         final widget = entry.value.call(context, attributes, element);
         return RawGestureDetector(
-            key: AnchorKey.of(context.parser.key, this),
+            key: AnchorKey.of(context.parser.key, this, context.parser),
           child: widget,
           gestures: {
             MultipleTapGestureRecognizer: GestureRecognizerFactoryWithHandlers<MultipleTapGestureRecognizer>(
@@ -121,7 +121,7 @@ class AudioContentElement extends ReplacedElement {
   @override
   Widget toWidget(RenderContext context) {
     return Container(
-      key: AnchorKey.of(context.parser.key, this),
+      key: AnchorKey.of(context.parser.key, this, context.parser),
       width: context.style.width ?? 300,
       height: Theme.of(context.buildContext).platform == TargetPlatform.android
           ? 48 : 75,
@@ -171,7 +171,7 @@ class VideoContentElement extends ReplacedElement {
     return AspectRatio(
       aspectRatio: _width / _height,
       child: Container(
-        key: AnchorKey.of(context.parser.key, this),
+        key: AnchorKey.of(context.parser.key, this, context.parser),
         child: Chewie(
           controller: ChewieController(
             videoPlayerController: VideoPlayerController.network(
@@ -210,7 +210,7 @@ class SvgContentElement extends ReplacedElement {
   Widget toWidget(RenderContext context) {
     return SvgPicture.string(
       data,
-      key: AnchorKey.of(context.parser.key, this),
+      key: AnchorKey.of(context.parser.key, this, context.parser),
       width: width,
       height: height,
     );
@@ -266,7 +266,7 @@ class RubyElement extends ReplacedElement {
       }
     });
     return Row(
-      key: AnchorKey.of(context.parser.key, this),
+      key: AnchorKey.of(context.parser.key, this, context.parser),
       crossAxisAlignment: CrossAxisAlignment.end,
       textBaseline: TextBaseline.alphabetic,
       mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
Fixes #677.

`strictMode` defaults false, so in this case any duplicate IDs are ignored (apart from the original one of course). Scrolling to the anchor is unaffected by this change, since it will just scroll to the one key that wasn't ignored. If it is true, then an exception will be thrown any time a duplicate ID is detected in the HTML.