### PR TITLE
Silently swallow duplicate ids

### DIFF
--- a/lib/src/anchor.dart
+++ b/lib/src/anchor.dart
@@ -3,19 +3,28 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_html/src/styled_element.dart';
 
 class AnchorKey extends GlobalKey {
+  static final Set<AnchorKey> _registry = <AnchorKey>{};
+
   final Key parentKey;
   final String id;
 
   const AnchorKey._(this.parentKey, this.id) : super.constructor();
 
   static AnchorKey? of(Key? parentKey, StyledElement? id) {
-    return forId(parentKey, id?.elementId);
+    final key = forId(parentKey, id?.elementId);
+    if (key == null || _registry.contains(key)) {
+      // Invalid id or already created a key with this id: silently ignore
+      return null;
+    }
+    _registry.add(key);
+    return key;
   }
 
   static AnchorKey? forId(Key? parentKey, String? id) {
     if (parentKey == null || id == null || id.isEmpty || id == "[[No ID]]") {
       return null;
     }
+
     return AnchorKey._(parentKey, id);
   }
 


### PR DESCRIPTION
Fixes #677 where an error would be throw if the html (incorrectly) uses multiple elements with the same id. While this is incorrect html, we are better off silently swallowing such cases (ignore any duplicates), just like a browser does.

Whilst a lenient/strictMode setting is possible, I have a hard time visualizing when one would explicitly want to crash/error in cases of duplicate ids, so it doesn't warrant added Yet Another Option for me.