### PR TITLE
Fix shrinkWrap by flowing the text to a new line for block elements

### DIFF
--- a/lib/src/replaced_element.dart
+++ b/lib/src/replaced_element.dart
@@ -283,13 +283,13 @@ class MathElement extends ReplacedElement {
     required this.element,
     this.texStr,
     String name = "math",
-  }) : super(name: name, alignment: PlaceholderAlignment.middle, style: Style(), elementId: element.id);
+  }) : super(name: name, alignment: PlaceholderAlignment.middle, style: Style(display: Display.BLOCK), elementId: element.id);
 
   @override
   Widget toWidget(RenderContext context) {
     texStr = parseMathRecursive(element, r'');
     return Container(
-      width: MediaQuery.of(context.buildContext).size.width,
+      width: context.parser.shrinkWrap ? null : MediaQuery.of(context.buildContext).size.width,
       child: Math.tex(
         texStr ?? '',
         mathStyle: MathStyle.display,


### PR DESCRIPTION
Fixes #565 and #671.

The same approach is used as PR #679 where a new line is inserted (when using shrinkWrap) for block element. The difference is that the insertion is done directly when processing block style elements.

No support for list items when using shrinkWrap, though this can be easily added I think. Tables and text aligning support is untested.

For example, this code:
```dart
        Column(
          crossAxisAlignment: CrossAxisAlignment.start,
          children: [
            Container(
              color: Colors.yellow,
              child: Html(
                data: "<strong>shrinkWrap: </strong> false",
                shrinkWrap: false,
              ),
            ),
            Container(
              color: Colors.orange,
              child: Html(
                data: "<h2>shrinkWrap</h2><p>use <strong>shrinkWrap</strong> to minimize the widget size</p><h2>false</h2>shrinkWrap is NOT enabled here",
                shrinkWrap: false,
              ),
            ),
            Container(
              color: Colors.yellow,
              child: Html(
                data: "<strong>shrinkWrap: </strong> true",
                shrinkWrap: true,
              ),
            ),
            Container(
              color: Colors.orange,
              child: Html(
                data: "<h2>shrinkWrap</h2><p>use <strong>shrinkWrap</strong> to minimize the widget size</p><h2>true</h2>shrinkWrap is enabled here",
                shrinkWrap: true,
              ),
            ),
          ],
        )
```

![Screenshot 2021-05-20 at 00 56 27](https://user-images.githubusercontent.com/196453/118895302-35e3dc80-b906-11eb-8ce4-9a491786195d.png)

There is still a small issue with replaced elements, where a new line should be inserted but it is not. I am debugging that still.