### PR TITLE
Add less hacky workaround for nested link and image tap detection

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -409,22 +409,17 @@ class HtmlParser extends StatelessWidget {
           );
         } else {
           return WidgetSpan(
-            child: RawGestureDetector(
-              key: AnchorKey.of(key, tree),
-              gestures: {
-                MultipleTapGestureRecognizer:
-                    GestureRecognizerFactoryWithHandlers<
-                        MultipleTapGestureRecognizer>(
-                  () => MultipleTapGestureRecognizer(),
-                  (instance) {
-                    instance
-                      ..onTap = _onAnchorTap != null
-                          ? () => _onAnchorTap!(tree.href, context, tree.attributes, tree.element)
-                          : null;
-                  },
-                ),
-              },
-              child: (childSpan as WidgetSpan).child,
+            child: MultipleTapGestureDetector(
+              onTap: _onAnchorTap != null
+                  ? () => _onAnchorTap!(tree.href, context, tree.attributes, tree.element)
+                  : null,
+              child: GestureDetector(
+                key: AnchorKey.of(key, tree),
+                onTap: _onAnchorTap != null
+                    ? () => _onAnchorTap!(tree.href, context, tree.attributes, tree.element)
+                    : null,
+                child: (childSpan as WidgetSpan).child,
+              ),
             ),
           );
         }

--- a/lib/src/replaced_element.dart
+++ b/lib/src/replaced_element.dart
@@ -83,16 +83,19 @@ class ImageContentElement extends ReplacedElement {
     for (final entry in context.parser.imageRenders.entries) {
       if (entry.key.call(attributes, element)) {
         final widget = entry.value.call(context, attributes, element);
-        return RawGestureDetector(
-            key: AnchorKey.of(context.parser.key, this),
-          child: widget,
-          gestures: {
-            MultipleTapGestureRecognizer: GestureRecognizerFactoryWithHandlers<MultipleTapGestureRecognizer>(
-                  () => MultipleTapGestureRecognizer(), (instance) {
-                instance..onTap = () => context.parser.onImageTap?.call(src, context, attributes, element);
+        return Builder(
+          builder: (buildContext) {
+            return GestureDetector(
+              key: AnchorKey.of(context.parser.key, this),
+              child: widget,
+              onTap: () {
+                if (MultipleTapGestureDetector.of(buildContext) != null) {
+                  MultipleTapGestureDetector.of(buildContext)!.onTap?.call();
+                }
+                context.parser.onImageTap?.call(src, context, attributes, element);
               },
-            ),
-          },
+            );
+          }
         );
       }
     }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -48,11 +48,21 @@ class Context<T> {
 
 // This class is a workaround so that both an image
 // and a link can detect taps at the same time.
-class MultipleTapGestureRecognizer extends TapGestureRecognizer {
-  @override
-  void rejectGesture(int pointer) {
-    acceptGesture(pointer);
+class MultipleTapGestureDetector extends InheritedWidget {
+  final void Function()? onTap;
+
+  const MultipleTapGestureDetector({
+    Key? key,
+    required Widget child,
+    required this.onTap,
+  }) : super(key: key, child: child);
+
+  static MultipleTapGestureDetector? of(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<MultipleTapGestureDetector>();
   }
+
+  @override
+  bool updateShouldNotify(MultipleTapGestureDetector oldWidget) => false;
 }
 
 class CustomBorderSide {


### PR DESCRIPTION
Fixes #690 and fixes #691

Got my idea from how `DropdownButtonHideUnderline` works. 