### PR TITLE
Add possibility to overwrite anchor links

### DIFF
--- a/lib/flutter_html.dart
+++ b/lib/flutter_html.dart
@@ -65,6 +65,7 @@ class Html extends StatelessWidget {
     GlobalKey? anchorKey,
     required this.data,
     this.onLinkTap,
+    this.onAnchorTap,
     this.customRender = const {},
     this.customImageRenders = const {},
     this.onCssParseError,
@@ -85,6 +86,7 @@ class Html extends StatelessWidget {
     GlobalKey? anchorKey,
     @required this.document,
     this.onLinkTap,
+    this.onAnchorTap,
     this.customRender = const {},
     this.customImageRenders = const {},
     this.onCssParseError,
@@ -111,6 +113,10 @@ class Html extends StatelessWidget {
 
   /// A function that defines what to do when a link is tapped
   final OnTap? onLinkTap;
+
+  /// A function that defines what to do when an anchor link is tapped. When this value is set,
+  /// the default anchor behaviour is overwritten.
+  final OnTap? onAnchorTap;
 
   /// An API that allows you to customize the entire process of image rendering.
   /// See the README for more details.
@@ -167,6 +173,7 @@ class Html extends StatelessWidget {
         key: _anchorKey,
         htmlData: doc,
         onLinkTap: onLinkTap,
+        onAnchorTap: onAnchorTap,
         onImageTap: onImageTap,
         onCssParseError: onCssParseError,
         onImageError: onImageError,

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -41,6 +41,7 @@ class HtmlParser extends StatelessWidget {
   final Key? key;
   final dom.Document htmlData;
   final OnTap? onLinkTap;
+  final OnTap? onAnchorTap;
   final OnTap? onImageTap;
   final OnCssParseError? onCssParseError;
   final ImageErrorListener? onImageError;
@@ -58,6 +59,7 @@ class HtmlParser extends StatelessWidget {
     required this.key,
     required this.htmlData,
     required this.onLinkTap,
+    required this.onAnchorTap,
     required this.onImageTap,
     required this.onCssParseError,
     required this.onImageError,
@@ -68,7 +70,12 @@ class HtmlParser extends StatelessWidget {
     required this.imageRenders,
     required this.tagsList,
     required this.navigationDelegateForIframe,
-  }): this._onAnchorTap = key != null ? _handleAnchorTap(key, onLinkTap): null, super(key: key);
+  })  : this._onAnchorTap = onAnchorTap != null
+          ? onAnchorTap
+          : key != null
+              ? _handleAnchorTap(key, onLinkTap)
+              : null,
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Currently it's not possible to overwrite the behavior of the anchor links. Since we use a ListView for the HTML widgets and need to use our own implementation for the anchor links, it is necessary for us to be able to overwrite the default behavior ourselves. Until recently, an anchor link triggered the onLinkTap. This no longer works.

Therefore, we have added a method that allows to include a custom implementation for the anchor links.