### PR TITLE
Fix css_parser null error when using CSS with @ declarations

### DIFF
--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -370,7 +370,11 @@ class DeclarationVisitor extends css.Visitor {
 
   @override
   void visitExpressions(css.Expressions node) {
-    _properties[_currentProperty]!.addAll(node.expressions);
+    if (_properties[_currentProperty] != null) {
+      _properties[_currentProperty]!.addAll(node.expressions);
+    } else {
+      _properties[_currentProperty] = node.expressions;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes #733, thanks @gbloggs for the solution.