### PR TITLE
Update Flutter Math Fork v0.3.3+1

### DIFF
--- a/example/lib/generated_plugin_registrant.dart
+++ b/example/lib/generated_plugin_registrant.dart
@@ -2,6 +2,7 @@
 // Generated file. Do not edit.
 //
 
+// ignore_for_file: directives_ordering
 // ignore_for_file: lines_longer_than_80_chars
 
 import 'package:video_player_web/video_player_web.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   flutter_svg: '>=0.22.0 <1.0.0'
 
   # Plugin for rendering MathML
-  flutter_math_fork: '>=0.3.2+1 <1.0.0'
+  flutter_math_fork: '>=0.3.3+1 <1.0.0'
 
   # plugin for firstWhereOrNull extension on lists
   collection: '>=1.15.0 <2.0.0'


### PR DESCRIPTION
- FIX broken dependency.

The latest Flutter v2.3.0-24.1.pre beta seems to have breaking changes to text selection.
Fix error:
```
../../flutter-sdk/.pub-cache/hosted/pub.dartlang.org/flutter_math_fork-0.3.3/lib/src/widgets/selection/handle_overlay.dart:197:58: Error: Too few positional arguments: 4 required, 3 given.
              child: widget.selectionControls.buildHandle(
```