### PR TITLE
fix: aspect ratio should never be NaN.

### DIFF
--- a/lib/image_render.dart
+++ b/lib/image_render.dart
@@ -225,13 +225,25 @@ double? _width(Map<String, String> attributes) {
   return widthString == null ? widthString as double? : double.tryParse(widthString);
 }
 
-double _aspectRatio(Map<String, String> attributes, AsyncSnapshot<Size> calculated) {
+double _aspectRatio(
+  Map<String, String> attributes,
+  AsyncSnapshot<Size> calculated,
+) {
+  double aspectRatio;
   final heightString = attributes["height"];
   final widthString = attributes["width"];
   if (heightString != null && widthString != null) {
     final height = double.tryParse(heightString);
     final width = double.tryParse(widthString);
-    return height == null || width == null ? calculated.data!.aspectRatio : width / height;
+    aspectRatio = height == null || width == null
+        ? calculated.data!.aspectRatio
+        : width / height;
+  } else {
+    aspectRatio = calculated.data!.aspectRatio;
   }
-  return calculated.data!.aspectRatio;
+  if (!aspectRatio.isNaN) {
+    return aspectRatio;
+  } else {
+    return 1;
+  }
 }


### PR DESCRIPTION
In `attributes` Map, when width & height both are "0", the `_aspectRatio` function was returning `NaN` instead some valid ratio.