### PR TITLE
Feature: Added selectionControls property to selectableHtml

### DIFF
--- a/lib/flutter_html.dart
+++ b/lib/flutter_html.dart
@@ -221,6 +221,7 @@ class SelectableHtml extends StatelessWidget {
     this.shrinkWrap = false,
     this.style = const {},
     this.tagsList = const [],
+    this.selectionControls
   }) : document = null,
         assert(data != null),
         _anchorKey = anchorKey ?? GlobalKey(),
@@ -236,6 +237,7 @@ class SelectableHtml extends StatelessWidget {
     this.shrinkWrap = false,
     this.style = const {},
     this.tagsList = const [],
+    this.selectionControls
   }) : data = null,
         assert(document != null),
         _anchorKey = anchorKey ?? GlobalKey(),
@@ -270,6 +272,10 @@ class SelectableHtml extends StatelessWidget {
   /// An API that allows you to override the default style for any HTML element
   final Map<String, Style> style;
 
+  /// Custom Selection controls allows you to override default toolbar and build custom toolbar
+  /// options
+  final TextSelectionControls? selectionControls;
+
   static List<String> get tags => new List<String>.from(SELECTABLE_ELEMENTS);
 
   @override
@@ -295,6 +301,7 @@ class SelectableHtml extends StatelessWidget {
         imageRenders: defaultImageRenders,
         tagsList: tagsList.isEmpty ? SelectableHtml.tags : tagsList,
         navigationDelegateForIframe: null,
+        selectionControls: selectionControls,
       ),
     );
   }

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -58,6 +58,7 @@ class HtmlParser extends StatelessWidget {
   final List<String> tagsList;
   final NavigationDelegate? navigationDelegateForIframe;
   final OnTap? _onAnchorTap;
+  final TextSelectionControls? selectionControls;
 
   HtmlParser({
     required this.key,
@@ -75,6 +76,7 @@ class HtmlParser extends StatelessWidget {
     required this.imageRenders,
     required this.tagsList,
     required this.navigationDelegateForIframe,
+    this.selectionControls
   })  : this._onAnchorTap = onAnchorTap != null
           ? onAnchorTap
           : key != null
@@ -125,6 +127,7 @@ class HtmlParser extends StatelessWidget {
           tree: cleanedTree,
           style: cleanedTree.style,
         ),
+        selectionControls: selectionControls,
       );
     }
     return StyledText(
@@ -1052,6 +1055,7 @@ class StyledText extends StatelessWidget {
   final RenderContext renderContext;
   final AnchorKey? key;
   final bool _selectable;
+  final TextSelectionControls? selectionControls;
 
   const StyledText({
     required this.textSpan,
@@ -1059,6 +1063,7 @@ class StyledText extends StatelessWidget {
     this.textScaleFactor = 1.0,
     required this.renderContext,
     this.key,
+    this.selectionControls,
   }) : _selectable = false,
         super(key: key);
 
@@ -1068,6 +1073,7 @@ class StyledText extends StatelessWidget {
     this.textScaleFactor = 1.0,
     required this.renderContext,
     this.key,
+    this.selectionControls
   }) : textSpan = textSpan,
         _selectable = true,
         super(key: key);
@@ -1082,6 +1088,7 @@ class StyledText extends StatelessWidget {
         textDirection: style.direction,
         textScaleFactor: textScaleFactor,
         maxLines: style.maxLines,
+        selectionControls: selectionControls,
       );
     }
     return SizedBox(


### PR DESCRIPTION
#801 

Implements #801 feature which allows specifying `selectionControls` property for `SelectableHtml` widget to override default toolbar and add custom options