### PR TITLE
Fix customRender example

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Widget html = Html(
           style: (context.tree.element!.attributes['horizontal'] != null)
               ? FlutterLogoStyle.horizontal
               : FlutterLogoStyle.markOnly,
-          textColor: context.style.color,
+          textColor: context.style.color!,
           size: context.style.fontSize!.size! * 5,
         );
       },


### PR DESCRIPTION
Add force unwrapping to style's color to get rid of `The argument type 'Color?' can't be assigned to the parameter type 'Color'` error.