### PR TITLE
Support widths and height css properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## [2.1.1] - July 27, 2021:
+## [2.1.1] - July 28, 2021:
+* Stable release with all 2.1.1-preview.X changes
+
+## [2.1.1-preview.0] - July 27, 2021:
 * Improves hr tag support
 * Fixes a leading whitespace issue
 * Fixes some crashes with CSS parsing

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,13 +61,17 @@ const htmlData = r"""
       <p>
       <q>Famous quote...</q>
       </p>
-      <table style="height: 400">
+      <table>
+      <colgroup>
+        <col width="50%" />
+        <col span="2" width="25%" />
+      </colgroup>
       <thead>
       <tr><th>One</th><th>Two</th><th>Three</th></tr>
       </thead>
       <tbody>
       <tr>
-        <td rowspan='2'>Rowspan</td><td>Data</td><td>Data</td>
+        <td rowspan='2'>Rowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan</td><td>Data</td><td>Data</td>
       </tr>
       <tr>
         <td colspan="2"><img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' /></td>
@@ -264,13 +268,13 @@ class _MyHomePageState extends State<MyHomePage> {
             'h5': Style(maxLines: 2, textOverflow: TextOverflow.ellipsis),
           },
           customRender: {
-            // "table": (context, child) {
-            //   return SingleChildScrollView(
-            //     scrollDirection: Axis.horizontal,
-            //     child:
-            //         (context.tree as TableLayoutElement).toWidget(context),
-            //   );
-            // },
+            "table": (context, child) {
+              return SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child:
+                    (context.tree as TableLayoutElement).toWidget(context),
+              );
+            },
             "bird": (RenderContext context, Widget child) {
               return TextSpan(text: "🐦");
             },

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,17 +61,13 @@ const htmlData = r"""
       <p>
       <q>Famous quote...</q>
       </p>
-      <table>
-      <colgroup>
-        <col width="50%" />
-        <col span="2" width="25%" />
-      </colgroup>
+      <table style="height: 400">
       <thead>
       <tr><th>One</th><th>Two</th><th>Three</th></tr>
       </thead>
       <tbody>
       <tr>
-        <td rowspan='2'>Rowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan</td><td>Data</td><td>Data</td>
+        <td rowspan='2'>Rowspan</td><td>Data</td><td>Data</td>
       </tr>
       <tr>
         <td colspan="2"><img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' /></td>
@@ -268,13 +264,13 @@ class _MyHomePageState extends State<MyHomePage> {
             'h5': Style(maxLines: 2, textOverflow: TextOverflow.ellipsis),
           },
           customRender: {
-            "table": (context, child) {
-              return SingleChildScrollView(
-                scrollDirection: Axis.horizontal,
-                child:
-                    (context.tree as TableLayoutElement).toWidget(context),
-              );
-            },
+            // "table": (context, child) {
+            //   return SingleChildScrollView(
+            //     scrollDirection: Axis.horizontal,
+            //     child:
+            //         (context.tree as TableLayoutElement).toWidget(context),
+            //   );
+            // },
             "bird": (RenderContext context, Widget child) {
               return TextSpan(text: "🐦");
             },

--- a/lib/src/css_parser.dart
+++ b/lib/src/css_parser.dart
@@ -194,6 +194,9 @@ Style declarationsToStyle(Map<String, List<css.Expression>> declarations) {
         case 'font-weight':
           style.fontWeight = ExpressionMapping.expressionToFontWeight(value.first);
           break;
+        case 'height':
+          style.height = ExpressionMapping.expressionToPaddingLength(value.first) ?? style.height;
+          break;
         case 'list-style-type':
           if (value.first is css.LiteralTerm) {
             style.listStyleType = ExpressionMapping.expressionToListStyleType(value.first as css.LiteralTerm) ?? style.listStyleType;
@@ -297,6 +300,9 @@ Style declarationsToStyle(Map<String, List<css.Expression>> declarations) {
           break;
         case 'text-shadow':
           style.textShadow = ExpressionMapping.expressionToTextShadow(value);
+          break;
+        case 'width':
+          style.width = ExpressionMapping.expressionToPaddingLength(value.first) ?? style.width;
           break;
       }
     }


### PR DESCRIPTION
Although we say the in README that we support the `height` and `width` css properties, we actually don't. This PR contains a basic implementation where we at least apply any exactly-defined width or height on the html element (container). You can now, for example, set the size of images. 

It only works on block style elements. This (to the best of my knowledge) is the same in browsers.

However, it does not implement support for percentage-based height/width as it is not as easy as setting this percentage on a Container. We could use a LayoutBuilder and then use the maxWidth * percentage, but this would not work if nested I think. Remains to be seen. Also, more work may be needed for elements such as tables. See #811 for a discussion specifically on tables.