### PR TITLE
Update low boundary of version range for chewie.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 
   # Plugins for rendering the <video> tag.
   video_player: '>=2.1.1 <3.0.0'
-  chewie: '>=1.0.0 <2.0.0'
+  chewie: '>=1.1.0 <2.0.0'
 
   # Plugin for rendering the <iframe> tag.
   webview_flutter: '>=2.0.4 <3.0.0'


### PR DESCRIPTION
To make sure the transitive wakelock dep is no less than 0.5.2 in order to avoid error with setMockMessageHandler.
This PR does minimal necessary change to prevent the conflict and does not aim to upgrade chewie to the latest version.
Issue  #844 