### PR TITLE
Ignore unsupported custom style selectors

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -273,9 +273,11 @@ class HtmlParser extends StatelessWidget {
   /// widget onto the [StyledElement] tree, no cascading of styles is done at this point.
   static StyledElement _applyCustomStyles(Map<String, Style> style, StyledElement tree) {
     style.forEach((key, style) {
-      if (tree.matchesSelector(key)) {
-        tree.style = tree.style.merge(style);
-      }
+      try {
+        if (tree.matchesSelector(key)) {
+          tree.style = tree.style.merge(style);
+        }
+      } catch (_) {}
     });
     tree.children.forEach((e) => _applyCustomStyles(style, e));
 


### PR DESCRIPTION
Pretty much the same as #779 except also applies to custom styles as well.

Useful as you may, for example, want to load some remote `.css` file that is not in the HTML `<link>` tags and then apply the styles using `Styles.fromCss(css)` but not have it crash from e.g. `:hover` pseudo-selectors.