### PR TITLE
upgrade flutter_math_fork version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   flutter_svg: '>=0.22.0 <1.0.0'
 
   # Plugin for rendering MathML
-  flutter_math_fork: '>=0.3.3+1 <1.0.0'
+  flutter_math_fork: '>=0.4.2+1 <1.0.0'
 
   # plugin for firstWhereOrNull extension on lists
   collection: '>=1.15.0 <2.0.0'


### PR DESCRIPTION
upgade flutter_mark_fork version because got problem in dev channel

```flutter/.pub-cache/hosted/pub.flutter-io.cn/flutter_math_fork-0.3.3+1/lib/src/widgets/selectable.dart:407:7: Error: The non-abstract class 'InternalSelectableMathState' is missing implementations for these members:

TextSelectionDelegate.copySelection
TextSelectionDelegate.cutSelection
TextSelectionDelegate.pasteText
TextSelectionDelegate.selectAll
Try to either
provide an implementation,
inherit an implementation from a superclass or mixin,
mark the class as abstract, or
provide a 'noSuchMethod' implementation.
class InternalSelectableMathState extends State
^^^^^^^^^^^^^^^^^^^^^^^^^^^
../../flutter/packages/flutter/lib/src/services/text_input.dart:948:8: Context: 'TextSelectionDelegate.copySelection' is defined here.
void copySelection(SelectionChangedCause cause) {
^^^^^^^^^^^^^
../../flutter/packages/flutter/lib/src/services/text_input.dart:872:8: Context: 'TextSelectionDelegate.cutSelection' is defined here.
void cutSelection(SelectionChangedCause cause) {
^^^^^^^^^^^^
../../flutter/packages/flutter/lib/src/services/text_input.dart:900:16: Context: 'TextSelectionDelegate.pasteText' is defined here.
Future pasteText(SelectionChangedCause cause) async {
^^^^^^^^^
../../flutter/packages/flutter/lib/src/services/text_input.dart:928:8: Context: 'TextSelectionDelegate.selectAll' is defined here.
void selectAll(SelectionChangedCause cause) {
^^^^^^^^^```