### PR TITLE
Add support for list-style: none

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -730,6 +730,9 @@ class HtmlParser extends StatelessWidget {
       }
     } else if (tree.style.display == Display.LIST_ITEM && tree.style.listStyleType != null) {
       switch (tree.style.listStyleType!) {
+        case ListStyleType.NONE:
+          tree.style.markerContent = '';
+          break;
         case ListStyleType.CIRCLE:
           tree.style.markerContent = '○';
           break;

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -530,6 +530,7 @@ enum ListStyleType {
   LOWER_ROMAN,
   UPPER_ROMAN,
   SQUARE,
+  NONE,
 }
 
 enum ListStylePosition {


### PR DESCRIPTION
It is impossible to remove bullet point for `li` without using customRender which is a bit overkill for something like this.
This PR adds a ListStyleType and remove bullet points for lists