### PR TITLE
Prevent crash on empty <table> tags

### DIFF
--- a/lib/src/layout_element.dart
+++ b/lib/src/layout_element.dart
@@ -155,6 +155,11 @@ class TableLayoutElement extends LayoutElement {
         max(0, columnMax - finalColumnSizes.length),
         (_) => IntrinsicContentTrackSize());
 
+    if (finalColumnSizes.isEmpty || rowSizes.isEmpty) {
+      // No actual cells to show
+      return SizedBox();
+    }
+
     return LayoutGrid(
       gridFit: GridFit.loose,
       columnSizes: finalColumnSizes,


### PR DESCRIPTION
Fixes #893 by checking in the end if there are actually any cells to render at all.

(Checking if <table> has any children is not enough becasue there might be non-tabular data inside that tag which should still render, annoyingly.)