### PR TITLE
Fix whitespace rendering between list items

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -949,7 +949,7 @@ class HtmlParser extends StatelessWidget {
       if (child is EmptyContentElement || child is EmptyLayoutElement) {
         toRemove.add(child);
       } else if (child is TextContentElement
-          && tree.name == "body"
+          && (tree.name == "body" || tree.name == "ul")
           && child.text!.replaceAll(' ', '').isEmpty) {
         toRemove.add(child);
       } else if (child is TextContentElement

--- a/lib/src/layout_element.dart
+++ b/lib/src/layout_element.dart
@@ -155,6 +155,11 @@ class TableLayoutElement extends LayoutElement {
         max(0, columnMax - finalColumnSizes.length),
         (_) => IntrinsicContentTrackSize());
 
+    if (finalColumnSizes.isEmpty || rowSizes.isEmpty) {
+      // No actual cells to show
+      return SizedBox();
+    }
+
     return LayoutGrid(
       gridFit: GridFit.loose,
       columnSizes: finalColumnSizes,


### PR DESCRIPTION
Fixes #878 as newlines and spaces between items in a `<ul>` should not create visible whitespace between them.