### PR TITLE
Fix list spacing render issue displaying a box

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -401,9 +401,11 @@ class HtmlParser extends StatelessWidget {
       );
     } else if (tree.style.display == Display.LIST_ITEM) {
       List<InlineSpan> getChildren(StyledElement tree) {
-        InlineSpan tabSpan = WidgetSpan(child: Text("\t", textAlign: TextAlign.right));
         List<InlineSpan> children = tree.children.map((tree) => parseTree(newContext, tree)).toList();
         if (tree.style.listStylePosition == ListStylePosition.INSIDE) {
+          final tabSpan = WidgetSpan(
+            child: Text("\t", textAlign: TextAlign.right, style: TextStyle(fontWeight: FontWeight.w400)),
+          );
           children.insert(0, tabSpan);
         }
         return children;
@@ -425,7 +427,7 @@ class HtmlParser extends StatelessWidget {
                 padding: tree.style.padding ?? EdgeInsets.only(left: tree.style.direction != TextDirection.rtl ? 10.0 : 0.0, right: tree.style.direction == TextDirection.rtl ? 10.0 : 0.0),
                 child: newContext.style.markerContent
               ) : Container(height: 0, width: 0),
-              Text("\t", textAlign: TextAlign.right),
+              Text("\t", textAlign: TextAlign.right, style: TextStyle(fontWeight: FontWeight.w400)),
               Expanded(
                   child: Padding(
                       padding: tree.style.listStylePosition == ListStylePosition.INSIDE ?

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -949,7 +949,7 @@ class HtmlParser extends StatelessWidget {
       if (child is EmptyContentElement || child is EmptyLayoutElement) {
         toRemove.add(child);
       } else if (child is TextContentElement
-          && tree.name == "body"
+          && (tree.name == "body" || tree.name == "ul")
           && child.text!.replaceAll(' ', '').isEmpty) {
         toRemove.add(child);
       } else if (child is TextContentElement

--- a/lib/src/layout_element.dart
+++ b/lib/src/layout_element.dart
@@ -155,6 +155,11 @@ class TableLayoutElement extends LayoutElement {
         max(0, columnMax - finalColumnSizes.length),
         (_) => IntrinsicContentTrackSize());
 
+    if (finalColumnSizes.isEmpty || rowSizes.isEmpty) {
+      // No actual cells to show
+      return SizedBox();
+    }
+
     return LayoutGrid(
       gridFit: GridFit.loose,
       columnSizes: finalColumnSizes,


### PR DESCRIPTION
Fixes list spacing render issue of #921 displaying a box (missing character) since low font weight rendering on iOS for tab chacters (among others) is bugged on Flutter. This fix forces a font weight of 400. This has no visual regression in spacing as a bold or thin tab character doesn't render wider or thinner anyway. 