### PR TITLE
Ensure non-negative insets are used for all margins and paddings

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -422,7 +422,7 @@ class HtmlParser extends StatelessWidget {
             children: [
               tree.style.listStylePosition == ListStylePosition.OUTSIDE ?
               Padding(
-                padding: tree.style.padding ?? EdgeInsets.only(left: tree.style.direction != TextDirection.rtl ? 10.0 : 0.0, right: tree.style.direction == TextDirection.rtl ? 10.0 : 0.0),
+                padding: tree.style.padding?.nonNegative ?? EdgeInsets.only(left: tree.style.direction != TextDirection.rtl ? 10.0 : 0.0, right: tree.style.direction == TextDirection.rtl ? 10.0 : 0.0),
                 child: newContext.style.markerContent
               ) : Container(height: 0, width: 0),
               Text("\t", textAlign: TextAlign.right),
@@ -1053,8 +1053,8 @@ class ContainerSpan extends StatelessWidget {
       ),
       height: style.height,
       width: style.width,
-      padding: style.padding,
-      margin: style.margin,
+      padding: style.padding?.nonNegative,
+      margin: style.margin?.nonNegative,
       alignment: shrinkWrap ? null : style.alignment,
       child: child ??
           StyledText(

--- a/lib/src/layout_element.dart
+++ b/lib/src/layout_element.dart
@@ -5,6 +5,7 @@ import 'package:flutter_html/html_parser.dart';
 import 'package:flutter_html/src/anchor.dart';
 import 'package:flutter_html/src/html_elements.dart';
 import 'package:flutter_html/src/styled_element.dart';
+import 'package:flutter_html/src/utils.dart';
 import 'package:flutter_html/style.dart';
 import 'package:flutter_layout_grid/flutter_layout_grid.dart';
 import 'package:html/dom.dart' as dom;
@@ -33,8 +34,8 @@ class TableLayoutElement extends LayoutElement {
   Widget toWidget(RenderContext context) {
     return Container(
       key: AnchorKey.of(context.parser.key, this),
-      margin: style.margin,
-      padding: style.padding,
+      padding: style.padding?.nonNegative,
+      margin: style.margin?.nonNegative,
       decoration: BoxDecoration(
         color: style.backgroundColor,
         border: style.border,
@@ -115,7 +116,7 @@ class TableLayoutElement extends LayoutElement {
           cells.add(GridPlacement(
             child: Container(
               width: double.infinity,
-              padding: child.style.padding ?? row.style.padding,
+              padding: child.style.padding?.nonNegative ?? row.style.padding?.nonNegative,
               decoration: BoxDecoration(
                 color: child.style.backgroundColor ?? row.style.backgroundColor,
                 border: child.style.border ?? row.style.border,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -112,3 +112,7 @@ extension TextTransformUtil on String? {
     }
   }
 }
+
+extension ClampedEdgeInsets on EdgeInsetsGeometry {
+  EdgeInsetsGeometry get nonNegative => this.clamp(EdgeInsets.zero, const EdgeInsets.all(double.infinity));
+}


### PR DESCRIPTION
Fix #919 by ensuring non-negative insets are used for all margins and paddings applied in the library.

While we (still) do not support negative margins/padding (because Flutter doesn't) this at least ensures it doesn't crash upon encountering negative inset values.