### PR TITLE
Disable click effect and decoration when a tag have no href attribute

### DIFF
--- a/lib/src/interactable_element.dart
+++ b/lib/src/interactable_element.dart
@@ -22,20 +22,30 @@ enum Gesture {
   TAP,
 }
 
-InteractableElement parseInteractableElement(
+StyledElement parseInteractableElement(
     dom.Element element, List<StyledElement> children) {
   switch (element.localName) {
     case "a":
-      return InteractableElement(
+      if (element.attributes.containsKey('href')) {
+        return InteractableElement(
+            name: element.localName!,
+            children: children,
+            href: element.attributes['href'],
+            style: Style(
+              color: Colors.blue,
+              textDecoration: TextDecoration.underline,
+            ),
+            node: element,
+            elementId: element.id
+        );
+      }
+      // When <a> tag have no href, it must be non clickable and without decoration.
+      return StyledElement(
         name: element.localName!,
         children: children,
-        href: element.attributes['href'],
-        style: Style(
-          color: Colors.blue,
-          textDecoration: TextDecoration.underline,
-        ),
+        style: Style(),
         node: element,
-        elementId: element.id
+        elementId: element.id,
       );
     /// will never be called, just to suppress missing return warning
     default:


### PR DESCRIPTION
When the "a" tag haven't the href attribute it must not be clickable and must not have decoration.