### PR TITLE
Fix block elements from producing bottom spacing

### DIFF
--- a/lib/custom_render.dart
+++ b/lib/custom_render.dart
@@ -214,6 +214,8 @@ CustomRender fallbackRender({Style? style, List<InlineSpan>? children}) =>
           .expand((tree) => [
         context.parser.parseTree(context, tree),
         if (tree.style.display == Display.BLOCK &&
+            tree.element?.parent?.localName != "th" &&
+            tree.element?.parent?.localName != "td" &&
             tree.element?.localName != "html" &&
             tree.element?.localName != "body")
           TextSpan(text: "\n"),

--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -550,6 +550,8 @@ class HtmlParser extends StatelessWidget {
             .expand((tree) => [
                   parseTree(newContext, tree),
                   if (tree.style.display == Display.BLOCK &&
+                      tree.element?.parent?.localName != "th" &&
+                      tree.element?.parent?.localName != "td" &&
                       tree.element?.localName != "html" &&
                       tree.element?.localName != "body")
                     TextSpan(text: "\n"),


### PR DESCRIPTION
Block style elements in table cells (td/th) should not produce block-like bottom spacing.

Example html:
```html
<p><br></p><table class=\"se-table-size-100 vrt-table vrt-table--no-offset\"><thead><tr><th><div>Nummer</div></th><th><div>Naam</div></th><th><div>Score</div></th></tr></thead><tbody><tr><td><div>1</div></td><td><div>Bergsvand</div></td><td><div>2</div></td></tr><tr><td><div>2</div></td><td><div>Graham Hansen</div></td><td><div>1</div></td></tr><tr><td><div>3</div></td><td><div>Terland&nbsp;</div></td><td><div>1</div></td></tr></tbody></table><p><br></p>
```

Should produce:
<p><br></p><table class=\"se-table-size-100 vrt-table vrt-table--no-offset\"><thead><tr><th><div>Nummer</div></th><th><div>Naam</div></th><th><div>Score</div></th></tr></thead><tbody><tr><td><div>1</div></td><td><div>Bergsvand</div></td><td><div>2</div></td></tr><tr><td><div>2</div></td><td><div>Graham Hansen</div></td><td><div>1</div></td></tr><tr><td><div>3</div></td><td><div>Terland&nbsp;</div></td><td><div>1</div></td></tr></tbody></table><p><br></p>

But instead it was producing:
![Screenshot 2021-12-15 at 16 30 19](https://user-images.githubusercontent.com/196453/146215829-706fb085-bce6-40e3-9cd0-3ad8302fffaf.png)

After my fix it looks like:
![Screenshot 2021-12-15 at 16 29 43](https://user-images.githubusercontent.com/196453/146215878-2fe3f1d0-b6e7-4eae-8c90-b2f8c502151e.png)

