### PR TITLE
Fix newlines in table

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ Widget html = Html(
     </thead>
     <tbody>
     <tr>
-    <td rowspan='2'>Rowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan</td><td>Data</td><td>Data</td>
+    <td rowspan='2'>Rowspan<br>Rowspan<br>Rowspan<br>Rowspan<br>Rowspan<br>Rowspan<br>Rowspan<br>Rowspan<br>Rowspan<br>Rowspan</td><td>Data</td><td>Data</td>
     </tr>
     <tr>
     <td colspan="2"><img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' /></td>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -73,7 +73,7 @@ const htmlData = r"""
       </thead>
       <tbody>
       <tr>
-        <td rowspan='2'>Rowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan\nRowspan</td><td>Data</td><td>Data</td>
+        <td rowspan='2'>Rowspan<br>Rowspan<br>Rowspan<br>Rowspan<br>Rowspan<br>Rowspan<br>Rowspan<br>Rowspan<br>Rowspan<br>Rowspan</td><td>Data</td><td>Data</td>
       </tr>
       <tr>
         <td colspan="2"><img alt='Google' src='https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_92x30dp.png' /></td>


### PR DESCRIPTION
This replaces `\n` with `<br>` in example app and readme.

<table>
  <tr>
    <td>Before</td>
     <td>After</td>
  </tr>
  <tr>
    <td>
<img src="https://user-images.githubusercontent.com/35694712/164884571-fd22850f-07b3-459b-806a-d075152cd871.png" width=270>
</td>
    <td>
<img src="https://user-images.githubusercontent.com/35694712/164884567-13acdd6b-b24e-4ea4-9a0d-f5b7f263f984.png" width=270>
</td>
  </tr>
 </table>

