### PR TITLE
Feature/add font family fallback

### DIFF
--- a/lib/style.dart
+++ b/lib/style.dart
@@ -37,6 +37,14 @@ class Style {
   /// Default: Theme.of(context).style.textTheme.body1.fontFamily
   String? fontFamily;
 
+
+  /// The list of font families to fall back on when a glyph cannot be found in default font family.
+  ///
+  /// Inherited: yes,
+  /// Default: null
+  List<String>? fontFamilyFallback;
+
+
   /// CSS attribute "`font-feature-settings`"
   ///
   /// Inherited: yes,
@@ -199,6 +207,7 @@ class Style {
     this.direction,
     this.display,
     this.fontFamily,
+    this.fontFamilyFallback,
     this.fontFeatureSettings,
     this.fontSize,
     this.fontStyle,
@@ -263,6 +272,7 @@ class Style {
       decorationStyle: textDecorationStyle,
       decorationThickness: textDecorationThickness,
       fontFamily: fontFamily,
+      fontFamilyFallback: fontFamilyFallback,
       fontFeatures: fontFeatureSettings,
       fontSize: fontSize?.size,
       fontStyle: fontStyle,
@@ -288,6 +298,7 @@ class Style {
       direction: other.direction,
       display: other.display,
       fontFamily: other.fontFamily,
+      fontFamilyFallback: other.fontFamilyFallback,
       fontFeatureSettings: other.fontFeatureSettings,
       fontSize: other.fontSize,
       fontStyle: other.fontStyle,
@@ -341,6 +352,7 @@ class Style {
       direction: child.direction ?? direction,
       display: display == Display.NONE ? display : child.display,
       fontFamily: child.fontFamily ?? fontFamily,
+      fontFamilyFallback: child.fontFamilyFallback ?? fontFamilyFallback,
       fontFeatureSettings: child.fontFeatureSettings ?? fontFeatureSettings,
       fontSize: finalFontSize,
       fontStyle: child.fontStyle ?? fontStyle,
@@ -368,6 +380,7 @@ class Style {
     TextDirection? direction,
     Display? display,
     String? fontFamily,
+    List<String>? fontFamilyFallback,
     List<FontFeature>? fontFeatureSettings,
     FontSize? fontSize,
     FontStyle? fontStyle,
@@ -405,6 +418,7 @@ class Style {
       direction: direction ?? this.direction,
       display: display ?? this.display,
       fontFamily: fontFamily ?? this.fontFamily,
+      fontFamilyFallback: fontFamilyFallback ?? this.fontFamilyFallback,
       fontFeatureSettings: fontFeatureSettings ?? this.fontFeatureSettings,
       fontSize: fontSize ?? this.fontSize,
       fontStyle: fontStyle ?? this.fontStyle,
@@ -446,6 +460,7 @@ class Style {
     this.textDecorationStyle = textStyle.decorationStyle;
     this.textDecorationThickness = textStyle.decorationThickness;
     this.fontFamily = textStyle.fontFamily;
+    this.fontFamilyFallback = textStyle.fontFamilyFallback;
     this.fontFeatureSettings = textStyle.fontFeatures;
     this.fontSize = FontSize(textStyle.fontSize);
     this.fontStyle = textStyle.fontStyle;


### PR DESCRIPTION
Add fontFamilyFallback param to Style and pass it to TextStyle. 

Usage: 
```dart
Html(
      data: '<span>‟Pessoas que se recuperaram, »’”›⸃⸅⸊⸍⸝⸡ [...]”</span>',
      style: <String, Style>{
        'span': Style(
          fontFamily: 'Lato',
          fontFamilyFallback: ['Arial', 'Roboto'],
        ),
      },
);
```

and can render characters that do not exist in the main fontFamily (and exist in any of fallback fontFamily, in order, of course): 
![image](https://user-images.githubusercontent.com/16167977/172063271-5d1d90f0-816d-43d6-9833-c57be100bdf8.png)

This pr can close #1078 