### PR TITLE
flutter_html_math: escape braces

### DIFF
--- a/packages/flutter_html_math/lib/flutter_html_math.dart
+++ b/packages/flutter_html_math/lib/flutter_html_math.dart
@@ -117,6 +117,8 @@ Map<String, String> _mathML2Tex = {
   "coth": r"\coth",
   "log": r"\log",
   "ln": r"\ln",
+  "{": r"\{",
+  "}": r"\}",
 };
 
 typedef OnMathError = Widget Function(


### PR DESCRIPTION
Brace character should be escaped on latex.

ex.
`<math><mo>{</mo></math>`