### PR TITLE
feat: Support mtable, mtd, mtr for draw matrix.

### DIFF
--- a/packages/flutter_html_math/lib/flutter_html_math.dart
+++ b/packages/flutter_html_math/lib/flutter_html_math.dart
@@ -39,7 +39,9 @@ CustomRenderMatcher mathMatcher() => (context) {
 String _parseMathRecursive(dom.Node node, String parsed) {
   if (node is dom.Element) {
     List<dom.Element> nodeList = node.nodes.whereType<dom.Element>().toList();
-    if (node.localName == "math" || node.localName == "mrow" || node.localName == "mtr") {
+    if (node.localName == "math" ||
+        node.localName == "mrow" ||
+        node.localName == "mtr") {
       for (var element in nodeList) {
         parsed = _parseMathRecursive(element, parsed);
       }
@@ -99,7 +101,8 @@ String _parseMathRecursive(dom.Node node, String parsed) {
       }
     }
     if (node.localName == 'mtable') {
-      String inner = nodeList.map((e) => _parseMathRecursive(e, '')).join(' \\\\');
+      String inner =
+          nodeList.map((e) => _parseMathRecursive(e, '')).join(' \\\\');
       parsed = '$parsed\\begin{matrix}$inner\\end{matrix}';
     }
     if (node.localName == "mtd") {

--- a/packages/flutter_html_math/lib/flutter_html_math.dart
+++ b/packages/flutter_html_math/lib/flutter_html_math.dart
@@ -103,9 +103,9 @@ String _parseMathRecursive(dom.Node node, String parsed) {
       parsed = '$parsed\\begin{matrix}$inner\\end{matrix}';
     }
     if (node.localName == "mtd") {
-      nodeList.forEach((element) {
+      for (var element in nodeList) {
         parsed = _parseMathRecursive(element, parsed);
-      });
+      }
       parsed = '$parsed & ';
     }
   }

--- a/packages/flutter_html_math/lib/flutter_html_math.dart
+++ b/packages/flutter_html_math/lib/flutter_html_math.dart
@@ -99,14 +99,14 @@ String _parseMathRecursive(dom.Node node, String parsed) {
       }
     }
     if (node.localName == 'mtable') {
-      String inner = nodeList.map((e) => parseMathRecursive(e, '')).join(' \\\\');
-      parsed = parsed + '\\begin{matrix}${inner}\\end{matrix}';
+      String inner = nodeList.map((e) => _parseMathRecursive(e, '')).join(' \\\\');
+      parsed = '$parsed\\begin{matrix}$inner\\end{matrix}';
     }
     if (node.localName == "mtd") {
       nodeList.forEach((element) {
-        parsed = parseMathRecursive(element, parsed);
+        parsed = _parseMathRecursive(element, parsed);
       });
-      parsed = parsed + ' & ';
+      parsed = '$parsed & ';
     }
   }
   return parsed;

--- a/packages/flutter_html_math/lib/flutter_html_math.dart
+++ b/packages/flutter_html_math/lib/flutter_html_math.dart
@@ -39,7 +39,7 @@ CustomRenderMatcher mathMatcher() => (context) {
 String _parseMathRecursive(dom.Node node, String parsed) {
   if (node is dom.Element) {
     List<dom.Element> nodeList = node.nodes.whereType<dom.Element>().toList();
-    if (node.localName == "math" || node.localName == "mrow") {
+    if (node.localName == "math" || node.localName == "mrow" || node.localName == "mtr") {
       for (var element in nodeList) {
         parsed = _parseMathRecursive(element, parsed);
       }
@@ -97,6 +97,16 @@ String _parseMathRecursive(dom.Node node, String parsed) {
       } else {
         parsed = parsed + node.text.trim();
       }
+    }
+    if (node.localName == 'mtable') {
+      String inner = nodeList.map((e) => parseMathRecursive(e, '')).join(' \\\\');
+      parsed = parsed + '\\begin{matrix}${inner}\\end{matrix}';
+    }
+    if (node.localName == "mtd") {
+      nodeList.forEach((element) {
+        parsed = parseMathRecursive(element, parsed);
+      });
+      parsed = parsed + ' & ';
     }
   }
   return parsed;


### PR DESCRIPTION
I want `mtable`, `mtr` and `mtd` for drawing matrix.

testcase:
```
  <math xmlns='http://www.w3.org/1998/Math/MathML'>
    <mtable>
      <mtr>
        <mtd>
          <mi>x</mi>
        </mtd>
        <mtd>
          <mn>3</mn>
        </mtd>
      </mtr>
      <mtr>
        <mtd>
          <mrow>
            <mo>-</mo>
            <mn>1</mn>
          </mrow>
        </mtd>
        <mtd>
          <mi>y</mi>
        </mtd>
      </mtr>
    </mtable>
  </math>
```

![スクリーンショット 2022-10-13 21 23 19](https://user-images.githubusercontent.com/8858287/195598653-bb4d8217-0928-4f36-b5b5-2374409d00b2.png)
