### PR TITLE
fix: Fix issue with font scaling introduced in 3.0.0-alpha.6

### DIFF
--- a/lib/src/css_box_widget.dart
+++ b/lib/src/css_box_widget.dart
@@ -87,16 +87,15 @@ class CssBoxWidget extends StatelessWidget {
       return Container();
     }
 
-    return Text.rich(
-      TextSpan(
+    return RichText(
+      text: TextSpan(
         style: style.generateTextStyle(),
         children: children,
       ),
-      style: style.generateTextStyle(),
-      textAlign: style.textAlign,
+      textAlign: style.textAlign ?? TextAlign.start,
       textDirection: style.direction,
       maxLines: style.maxLines,
-      overflow: style.textOverflow,
+      overflow: style.textOverflow ?? TextOverflow.clip,
     );
   }
 

--- a/lib/src/style/fontsize.dart
+++ b/lib/src/style/fontsize.dart
@@ -5,11 +5,7 @@ class FontSize extends LengthOrPercent {
 
   // These values are calculated based off of the default (`medium`)
   // being 14px.
-  //
-  // TODO(Sub6Resources): This seems to override Flutter's accessibility text scaling.
-  //
-  // Negative values are computed during parsing to be a percentage of
-  // the parent style's font size.
+  // TODO calculate from https://w3c.github.io/csswg-drafts/css-fonts-3/#absolute-size-value
   static final xxSmall = FontSize(7.875);
   static final xSmall = FontSize(8.75);
   static final small = FontSize(11.375);


### PR DESCRIPTION
Fixes #1170 

I inadvertently used `Text.rich`, which doesn't handle accessibility or font scaling very well, instead of `RichText` in `CssBoxWidget`. This reverts that issue.