### PR TITLE
Optional properties: selectable, placeholderAlignment.

### DIFF
--- a/lib/custom_render.dart
+++ b/lib/custom_render.dart
@@ -129,7 +129,7 @@ CustomRender blockElementRender({Style? style, List<InlineSpan>? children}) =>
         );
       }
       return WidgetSpan(
-        alignment: PlaceholderAlignment.baseline,
+        alignment: style?.placeholderAlignment ?? PlaceholderAlignment.bottom,
         baseline: TextBaseline.alphabetic,
         child: CssBoxWidget.withInlineSpanChildren(
           key: context.key,

--- a/lib/flutter_html.dart
+++ b/lib/flutter_html.dart
@@ -62,6 +62,7 @@ class Html extends StatefulWidget {
     this.onImageTap,
     this.tagsList = const [],
     this.style = const {},
+    this.selectable = false,
   })  : documentElement = null,
         assert(data != null),
         _anchorKey = anchorKey ?? GlobalKey(),
@@ -80,6 +81,7 @@ class Html extends StatefulWidget {
     this.onImageTap,
     this.tagsList = const [],
     this.style = const {},
+    this.selectable = false,
   })  : data = null,
         assert(document != null),
         documentElement = document!.documentElement,
@@ -99,6 +101,7 @@ class Html extends StatefulWidget {
     this.onImageTap,
     this.tagsList = const [],
     this.style = const {},
+    this.selectable = false,
   })  : data = null,
         assert(documentElement != null),
         _anchorKey = anchorKey ?? GlobalKey(),
@@ -142,6 +145,9 @@ class Html extends StatefulWidget {
 
   /// An API that allows you to override the default style for any HTML element
   final Map<String, Style> style;
+
+  /// Makes the text in the widget selectable.
+  final bool selectable;
 
   static List<String> get tags => List<String>.from(HtmlElements.styledElements)
     ..addAll(HtmlElements.interactableElements)
@@ -188,7 +194,7 @@ class _HtmlState extends State<Html> {
       onCssParseError: widget.onCssParseError,
       onImageError: widget.onImageError,
       shrinkWrap: widget.shrinkWrap,
-      selectable: false,
+      selectable: widget.selectable,
       style: widget.style,
       customRenders: {}
         ..addAll(widget.customRenders)

--- a/lib/style.dart
+++ b/lib/style.dart
@@ -215,6 +215,11 @@ class Style {
   Alignment? alignment;
   Widget? markerContent;
 
+  /// Where to vertically align the placeholder relative to the surrounding text.
+  ///
+  /// Default: [PlaceholderAlignment.bottom]
+  PlaceholderAlignment? placeholderAlignment;
+
   /// MaxLine
   ///
   ///
@@ -271,6 +276,7 @@ class Style {
     this.maxLines,
     this.textOverflow,
     this.textTransform = TextTransform.none,
+    this.placeholderAlignment = PlaceholderAlignment.bottom,
   }) {
     if (alignment == null &&
         (display == Display.block || display == Display.listItem)) {

--- a/packages/flutter_html_all/pubspec.yaml
+++ b/packages/flutter_html_all/pubspec.yaml
@@ -11,25 +11,47 @@ dependencies:
   flutter:
     sdk: flutter
   html: '>=0.15.0 <1.0.0'
-  flutter_html: ^3.0.0-alpha.6
-  flutter_html_audio: ^3.0.0-alpha.4
-  flutter_html_iframe: ^3.0.0-alpha.4
-  flutter_html_math: ^3.0.0-alpha.4
-  flutter_html_svg: ^3.0.0-alpha.4
-  flutter_html_table: ^3.0.0-alpha.4
-  flutter_html_video: ^3.0.0-alpha.5
-#  flutter_html_audio:
-#    path: ../flutter_html_audio
-#  flutter_html_iframe:
-#    path: ../flutter_html_iframe
-#  flutter_html_math:
-#    path: ../flutter_html_math
-#  flutter_html_svg:
-#    path: ../flutter_html_svg
-#  flutter_html_table:
-#    path: ../flutter_html_table
-#  flutter_html_video:
-#    path: ../flutter_html_video
+  # flutter_html: ^3.0.0-alpha.6
+  # flutter_html_audio: ^3.0.0-alpha.4
+  # flutter_html_iframe: ^3.0.0-alpha.4
+  # flutter_html_math: ^3.0.0-alpha.4
+  # flutter_html_svg: ^3.0.0-alpha.4
+  # flutter_html_table: ^3.0.0-alpha.4
+  # flutter_html_video: ^3.0.0-alpha.5
+  flutter_html:
+    git:
+      url: git@github.com:darkstarx/flutter_html.git
+      ref: master
+  flutter_html_audio:
+    git:
+      url: git@github.com:darkstarx/flutter_html.git
+      path: packages/flutter_html_audio
+      ref: master
+  flutter_html_iframe:
+    git:
+      url: git@github.com:darkstarx/flutter_html.git
+      path: packages/flutter_html_iframe
+      ref: master
+  flutter_html_math:
+    git:
+      url: git@github.com:darkstarx/flutter_html.git
+      path: packages/flutter_html_math
+      ref: master
+  flutter_html_svg:
+    git:
+      url: git@github.com:darkstarx/flutter_html.git
+      path: packages/flutter_html_svg
+      ref: master
+  flutter_html_table:
+    git:
+      url: git@github.com:darkstarx/flutter_html.git
+      path: packages/flutter_html_table
+      ref: master
+  flutter_html_video:
+    git:
+      url: git@github.com:darkstarx/flutter_html.git
+      path: packages/flutter_html_video
+      ref: master
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_html_audio/pubspec.yaml
+++ b/packages/flutter_html_audio/pubspec.yaml
@@ -11,9 +11,11 @@ dependencies:
   flutter:
     sdk: flutter
   html: '>=0.15.0 <1.0.0'
-  flutter_html: ^3.0.0-alpha.6
-#  flutter_html:
-#    path: ../..
+  # flutter_html: ^3.0.0-alpha.6
+  flutter_html:
+    git:
+      url: git@github.com:darkstarx/flutter_html.git
+      ref: master
 
   video_player: '>=2.2.8 <3.0.0'
   chewie_audio: '>=1.3.0 <2.0.0'

--- a/packages/flutter_html_iframe/pubspec.yaml
+++ b/packages/flutter_html_iframe/pubspec.yaml
@@ -11,9 +11,11 @@ dependencies:
   flutter:
     sdk: flutter
   html: '>=0.15.0 <1.0.0'
-  flutter_html: ^3.0.0-alpha.6
-#  flutter_html:
-#    path: ../..
+  # flutter_html: ^3.0.0-alpha.6
+  flutter_html:
+    git:
+      url: git@github.com:darkstarx/flutter_html.git
+      ref: master
 
   webview_flutter: '>=2.0.4 <4.0.0'
 

--- a/packages/flutter_html_math/pubspec.yaml
+++ b/packages/flutter_html_math/pubspec.yaml
@@ -11,9 +11,11 @@ dependencies:
   flutter:
     sdk: flutter
   html: '>=0.15.0 <1.0.0'
-  flutter_html: ^3.0.0-alpha.6
-#  flutter_html:
-#    path: ../..
+  # flutter_html: ^3.0.0-alpha.6
+  flutter_html:
+    git:
+      url: git@github.com:darkstarx/flutter_html.git
+      ref: master
 
   flutter_math_fork: '>=0.6.0 <1.0.0'
 

--- a/packages/flutter_html_svg/pubspec.yaml
+++ b/packages/flutter_html_svg/pubspec.yaml
@@ -11,9 +11,11 @@ dependencies:
   flutter:
     sdk: flutter
   html: '>=0.15.0 <1.0.0'
-  flutter_html: ^3.0.0-alpha.6
-#  flutter_html:
-#    path: ../..
+  # flutter_html: ^3.0.0-alpha.6
+  flutter_html:
+    git:
+      url: git@github.com:darkstarx/flutter_html.git
+      ref: master
 
   flutter_svg: '>=1.0.0 <2.0.0'
 

--- a/packages/flutter_html_table/pubspec.yaml
+++ b/packages/flutter_html_table/pubspec.yaml
@@ -12,9 +12,11 @@ dependencies:
   flutter:
     sdk: flutter
   html: '>=0.15.0 <1.0.0'
-  flutter_html: ^3.0.0-alpha.6
-#  flutter_html:
-#    path: ../..
+  # flutter_html: ^3.0.0-alpha.6
+  flutter_html:
+    git:
+      url: git@github.com:darkstarx/flutter_html.git
+      ref: master
 
   flutter_layout_grid: '>=1.0.1 <2.0.0'
 

--- a/packages/flutter_html_video/pubspec.yaml
+++ b/packages/flutter_html_video/pubspec.yaml
@@ -11,9 +11,11 @@ dependencies:
   flutter:
     sdk: flutter
   html: '>=0.15.0 <1.0.0'
-  flutter_html: ^3.0.0-alpha.6
-#  flutter_html:
-#    path: ../..
+  # flutter_html: ^3.0.0-alpha.6
+  flutter_html:
+    git:
+      url: git@github.com:darkstarx/flutter_html.git
+      ref: master
 
   video_player: '>=2.2.8 <3.0.0'
   chewie: '>=1.1.0 <2.0.0'


### PR DESCRIPTION
To eliminate the issue of using this widget inside the `IntrinsicHeight`, we must temporary discard of using baseline alignment. This PR makes this property `bottom` by default and still allows to customize the value to keep the widget ready to use when the Flutter issue https://github.com/flutter/flutter/issues/65895 is solved (by configuring the `placeholderAlignment` property for specific tags in the `style` property). Also it makes the property `selectable` customizable as well.