### PR TITLE
Fix missing headers parameter

### DIFF
--- a/lib/custom_render.dart
+++ b/lib/custom_render.dart
@@ -287,7 +287,8 @@ CustomRender networkImageRender({
       if (context.parser.cachedImageSizes[src] != null) {
         completer.complete(context.parser.cachedImageSizes[src]);
       } else {
-        Image image = Image.network(src, frameBuilder: (ctx, child, frame, _) {
+        Image image = Image.network(src, headers: headers,
+            frameBuilder: (ctx, child, frame, _) {
           if (frame == null) {
             if (!completer.isCompleted) {
               completer.completeError("error");


### PR DESCRIPTION
When using a `networkImageRender()`, the header value is not taken into account when computing the image size.
If the headers are used for authentication, the image will never load.