### PR TITLE
Fix: Aspect ratio exception when height is 0

### DIFF
--- a/lib/custom_render.dart
+++ b/lib/custom_render.dart
@@ -535,7 +535,7 @@ double _aspectRatio(
   if (heightString != null && widthString != null) {
     final height = double.tryParse(heightString);
     final width = double.tryParse(widthString);
-    return height == null || width == null
+    return height == null || width == null || height == 0.0 
         ? calculated.data!.aspectRatio
         : width / height;
   }


### PR DESCRIPTION
Error: 'package:flutter/src/widgets/basic.dart': Failed assertion: line 3294 pos 15: 'aspectRatio > 0.0': is not true.

When height is 0, aspect ratio error occurs. By returning aspect ratio is 1 when height is 0 then the problem gets solved.