### PR TITLE
Upgrade flutter_svg

### DIFF
--- a/packages/flutter_html_svg/pubspec.yaml
+++ b/packages/flutter_html_svg/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 #  flutter_html:
 #    path: ../..
 
-  flutter_svg: '>=1.0.0 <2.0.0'
+  flutter_svg: ^2.0.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
There isn't any reason to keep an old flutter_svg version.

So I encourage to upgrade it.