### PR TITLE
Corrected accessibility text scaling

### DIFF
--- a/lib/html_parser.dart
+++ b/lib/html_parser.dart
@@ -104,6 +104,7 @@ class HtmlParser extends StatelessWidget {
       scrollPhysics: scrollPhysics,
       selectionControls: selectionControls,
       shrinkWrap: shrinkWrap,
+      top: true,
     );
   }
 

--- a/lib/src/css_box_widget.dart
+++ b/lib/src/css_box_widget.dart
@@ -12,6 +12,7 @@ class CssBoxWidget extends StatelessWidget {
     this.textDirection,
     this.childIsReplaced = false,
     this.shrinkWrap = false,
+    this.top = false,
   });
 
   /// Generates a CSSBoxWidget that contains a list of InlineSpan children.
@@ -23,6 +24,7 @@ class CssBoxWidget extends StatelessWidget {
     this.childIsReplaced = false,
     this.shrinkWrap = false,
     bool selectable = false,
+    this.top = false,
     TextSelectionControls? selectionControls,
     ScrollPhysics? scrollPhysics,
   }) : child = selectable
@@ -55,11 +57,12 @@ class CssBoxWidget extends StatelessWidget {
   /// necessarily take up the full available width unless necessary
   final bool shrinkWrap;
 
+  /// For the root widget, so textScaleFactor etc are only applied once
+  final bool top;
+
   @override
   Widget build(BuildContext context) {
-    final markerBox = style.listStylePosition == ListStylePosition.outside
-        ? _generateMarkerBoxSpan(style)
-        : null;
+    final markerBox = style.listStylePosition == ListStylePosition.outside ? _generateMarkerBoxSpan(style) : null;
 
     return _CSSBoxRenderer(
       width: style.width ?? Width.auto(),
@@ -74,14 +77,13 @@ class CssBoxWidget extends StatelessWidget {
       shrinkWrap: shrinkWrap,
       children: [
         Container(
-          decoration: BoxDecoration(
-            border: style.border,
-            color: style.backgroundColor, //Colors the padding and content boxes
-          ),
-          width: _shouldExpandToFillBlock() ? double.infinity : null,
-          padding: style.padding ?? EdgeInsets.zero,
-          child: child,
-        ),
+            decoration: BoxDecoration(
+              border: style.border,
+              color: style.backgroundColor, //Colors the padding and content boxes
+            ),
+            width: _shouldExpandToFillBlock() ? double.infinity : null,
+            padding: style.padding ?? EdgeInsets.zero,
+            child: top ? child : MediaQuery(data: MediaQuery.of(context).copyWith(textScaleFactor: 1.0), child: child)),
         if (markerBox != null) Text.rich(markerBox),
       ],
     );
@@ -103,8 +105,8 @@ class CssBoxWidget extends StatelessWidget {
       }
     }
 
-    return RichText(
-      text: TextSpan(
+    return Text.rich(
+      TextSpan(
         style: style.generateTextStyle(),
         children: children,
       ),
@@ -148,8 +150,7 @@ class CssBoxWidget extends StatelessWidget {
           child: Image.network(
             style.listStyleImage!.uriText,
             errorBuilder: (_, __, ___) {
-              if (style.marker?.content.replacementContent?.isNotEmpty ??
-                  false) {
+              if (style.marker?.content.replacementContent?.isNotEmpty ?? false) {
                 return Text.rich(
                   TextSpan(
                     text: style.marker!.content.replacementContent!,
@@ -180,14 +181,10 @@ class CssBoxWidget extends StatelessWidget {
   /// width available to it or if it should just let its inner content
   /// determine the content-box's width.
   bool _shouldExpandToFillBlock() {
-    return (style.display == Display.block ||
-            style.display == Display.listItem) &&
-        !childIsReplaced &&
-        !shrinkWrap;
+    return (style.display == Display.block || style.display == Display.listItem) && !childIsReplaced && !shrinkWrap;
   }
 
-  TextDirection _checkTextDirection(
-      BuildContext context, TextDirection? direction) {
+  TextDirection _checkTextDirection(BuildContext context, TextDirection? direction) {
     final textDirection = direction ?? Directionality.maybeOf(context);
 
     assert(
@@ -321,9 +318,7 @@ class _CSSBoxRenderer extends MultiChildRenderObjectWidget {
 
 /// Implements the CSS layout algorithm
 class _RenderCSSBox extends RenderBox
-    with
-        ContainerRenderObjectMixin<RenderBox, CSSBoxParentData>,
-        RenderBoxContainerDefaultsMixin<RenderBox, CSSBoxParentData> {
+    with ContainerRenderObjectMixin<RenderBox, CSSBoxParentData>, RenderBoxContainerDefaultsMixin<RenderBox, CSSBoxParentData> {
   _RenderCSSBox({
     required Display display,
     required Width width,
@@ -432,13 +427,11 @@ class _RenderCSSBox extends RenderBox
     }
   }
 
-  static double getIntrinsicDimension(RenderBox? firstChild,
-      double Function(RenderBox child) mainChildSizeGetter) {
+  static double getIntrinsicDimension(RenderBox? firstChild, double Function(RenderBox child) mainChildSizeGetter) {
     double extent = 0.0;
     RenderBox? child = firstChild;
     while (child != null) {
-      final CSSBoxParentData childParentData =
-          child.parentData! as CSSBoxParentData;
+      final CSSBoxParentData childParentData = child.parentData! as CSSBoxParentData;
       extent = math.max(extent, mainChildSizeGetter(child));
       assert(child.parentData == childParentData);
       child = childParentData.nextSibling;
@@ -448,26 +441,22 @@ class _RenderCSSBox extends RenderBox
 
   @override
   double computeMinIntrinsicWidth(double height) {
-    return getIntrinsicDimension(
-        firstChild, (RenderBox child) => child.getMinIntrinsicWidth(height));
+    return getIntrinsicDimension(firstChild, (RenderBox child) => child.getMinIntrinsicWidth(height));
   }
 
   @override
   double computeMaxIntrinsicWidth(double height) {
-    return getIntrinsicDimension(
-        firstChild, (RenderBox child) => child.getMaxIntrinsicWidth(height));
+    return getIntrinsicDimension(firstChild, (RenderBox child) => child.getMaxIntrinsicWidth(height));
   }
 
   @override
   double computeMinIntrinsicHeight(double width) {
-    return getIntrinsicDimension(
-        firstChild, (RenderBox child) => child.getMinIntrinsicHeight(width));
+    return getIntrinsicDimension(firstChild, (RenderBox child) => child.getMinIntrinsicHeight(width));
   }
 
   @override
   double computeMaxIntrinsicHeight(double width) {
-    return getIntrinsicDimension(
-        firstChild, (RenderBox child) => child.getMaxIntrinsicHeight(width));
+    return getIntrinsicDimension(firstChild, (RenderBox child) => child.getMaxIntrinsicHeight(width));
   }
 
   @override
@@ -483,9 +472,7 @@ class _RenderCSSBox extends RenderBox
     ).parentSize;
   }
 
-  _Sizes _computeSize(
-      {required BoxConstraints constraints,
-      required ChildLayouter layoutChild}) {
+  _Sizes _computeSize({required BoxConstraints constraints, required ChildLayouter layoutChild}) {
     if (childCount == 0) {
       return _Sizes(constraints.biggest, Size.zero);
     }
@@ -504,14 +491,10 @@ class _RenderCSSBox extends RenderBox
     final childConstraints = constraints.copyWith(
       maxWidth: (this.width.unit != Unit.auto)
           ? this.width.value
-          : containingBlockSize.width -
-              (margins.left?.value ?? 0) -
-              (margins.right?.value ?? 0),
+          : containingBlockSize.width - (margins.left?.value ?? 0) - (margins.right?.value ?? 0),
       maxHeight: (this.height.unit != Unit.auto)
           ? this.height.value
-          : containingBlockSize.height -
-              (margins.top?.value ?? 0) -
-              (margins.bottom?.value ?? 0),
+          : containingBlockSize.height - (margins.top?.value ?? 0) - (margins.bottom?.value ?? 0),
       minWidth: (this.width.unit != Unit.auto) ? this.width.value : 0,
       minHeight: (this.height.unit != Unit.auto) ? this.height.value : 0,
     );
@@ -522,18 +505,14 @@ class _RenderCSSBox extends RenderBox
 
     // Calculate used values of margins based on rules
     final usedMargins = _calculateUsedMargins(childSize, containingBlockSize);
-    final horizontalMargins =
-        (usedMargins.left?.value ?? 0) + (usedMargins.right?.value ?? 0);
-    final verticalMargins =
-        (usedMargins.top?.value ?? 0) + (usedMargins.bottom?.value ?? 0);
+    final horizontalMargins = (usedMargins.left?.value ?? 0) + (usedMargins.right?.value ?? 0);
+    final verticalMargins = (usedMargins.top?.value ?? 0) + (usedMargins.bottom?.value ?? 0);
 
     //Calculate Width and Height of CSS Box
     height = childSize.height;
     switch (display) {
       case Display.block:
-        width = (shrinkWrap || childIsReplaced)
-            ? childSize.width + horizontalMargins
-            : containingBlockSize.width;
+        width = (shrinkWrap || childIsReplaced) ? childSize.width + horizontalMargins : containingBlockSize.width;
         height = childSize.height + verticalMargins;
         break;
       case Display.inline:
@@ -545,9 +524,7 @@ class _RenderCSSBox extends RenderBox
         height = childSize.height + verticalMargins;
         break;
       case Display.listItem:
-        width = shrinkWrap
-            ? childSize.width + horizontalMargins
-            : containingBlockSize.width;
+        width = shrinkWrap ? childSize.width + horizontalMargins : containingBlockSize.width;
         height = childSize.height + verticalMargins;
         break;
       case Display.none:
@@ -572,12 +549,10 @@ class _RenderCSSBox extends RenderBox
     assert(firstChild != null);
     RenderBox child = firstChild!;
 
-    final CSSBoxParentData childParentData =
-        child.parentData! as CSSBoxParentData;
+    final CSSBoxParentData childParentData = child.parentData! as CSSBoxParentData;
 
     // Calculate used margins based on constraints and child size
-    final usedMargins =
-        _calculateUsedMargins(sizes.childSize, constraints.biggest);
+    final usedMargins = _calculateUsedMargins(sizes.childSize, constraints.biggest);
     final leftMargin = usedMargins.left?.value ?? 0;
     final topMargin = usedMargins.top?.value ?? 0;
 
@@ -610,13 +585,8 @@ class _RenderCSSBox extends RenderBox
     RenderBox? markerBox = childParentData.nextSibling;
     if (markerBox != null) {
       final markerBoxParentData = markerBox.parentData! as CSSBoxParentData;
-      final distance = (child.getDistanceToBaseline(TextBaseline.alphabetic,
-                  onlyReal: true) ??
-              0) +
-          topOffset;
-      final offsetHeight = distance -
-          (markerBox.getDistanceToBaseline(TextBaseline.alphabetic) ??
-              markerBox.size.height);
+      final distance = (child.getDistanceToBaseline(TextBaseline.alphabetic, onlyReal: true) ?? 0) + topOffset;
+      final offsetHeight = distance - (markerBox.getDistanceToBaseline(TextBaseline.alphabetic) ?? markerBox.size.height);
       markerBoxParentData.offset = Offset(-markerBox.size.width, offsetHeight);
     }
   }
@@ -648,8 +618,7 @@ class _RenderCSSBox extends RenderBox
       // width of the containing block, then consider left and right margins to
       // have a 0 value.
       if (!widthIsAuto) {
-        if ((childSize.width + marginLeft.value + marginRight.value) >
-            containingBlockSize.width) {
+        if ((childSize.width + marginLeft.value + marginRight.value) > containingBlockSize.width) {
           //Treat auto values of margin left and margin right as 0 for following rules
           marginLeft = Margin(0);
           marginRight = Margin(0);
@@ -661,22 +630,16 @@ class _RenderCSSBox extends RenderBox
       // If all values are non-auto, the box is overconstrained.
       // One of the margins will need to be adjusted so that the
       // entire width of the containing block is used.
-      if (!widthIsAuto &&
-          !marginLeftIsAuto &&
-          !marginRightIsAuto &&
-          !shrinkWrap &&
-          !childIsReplaced) {
+      if (!widthIsAuto && !marginLeftIsAuto && !marginRightIsAuto && !shrinkWrap && !childIsReplaced) {
         //Ignore either left or right margin based on textDirection.
 
         switch (textDirection) {
           case TextDirection.rtl:
-            final difference =
-                containingBlockSize.width - childSize.width - marginRight.value;
+            final difference = containingBlockSize.width - childSize.width - marginRight.value;
             marginLeft = Margin(difference);
             break;
           case TextDirection.ltr:
-            final difference =
-                containingBlockSize.width - childSize.width - marginLeft.value;
+            final difference = containingBlockSize.width - childSize.width - marginLeft.value;
             marginRight = Margin(difference);
             break;
         }
@@ -686,12 +649,10 @@ class _RenderCSSBox extends RenderBox
       if (widthIsAuto && !marginLeftIsAuto && !marginRightIsAuto) {
         widthIsAuto = false;
       } else if (!widthIsAuto && marginLeftIsAuto && !marginRightIsAuto) {
-        marginLeft = Margin(
-            containingBlockSize.width - childSize.width - marginRight.value);
+        marginLeft = Margin(containingBlockSize.width - childSize.width - marginRight.value);
         marginLeftIsAuto = false;
       } else if (!widthIsAuto && !marginLeftIsAuto && marginRightIsAuto) {
-        marginRight = Margin(
-            containingBlockSize.width - childSize.width - marginLeft.value);
+        marginRight = Margin(containingBlockSize.width - childSize.width - marginLeft.value);
         marginRightIsAuto = false;
       }
 
@@ -712,8 +673,7 @@ class _RenderCSSBox extends RenderBox
       //If both margin-left and margin-right are auto, their used values are equal.
       // This horizontally centers the element within the containing block.
       if (marginLeftIsAuto && marginRightIsAuto) {
-        final newMargin =
-            Margin((containingBlockSize.width - childSize.width) / 2);
+        final newMargin = Margin((containingBlockSize.width - childSize.width) / 2);
         marginLeft = newMargin;
         marginRight = newMargin;
         marginLeftIsAuto = false;
@@ -724,11 +684,7 @@ class _RenderCSSBox extends RenderBox
       assert(!marginLeftIsAuto && !marginRightIsAuto && !widthIsAuto);
     }
 
-    return Margins(
-        left: marginLeft,
-        right: marginRight,
-        top: margins.top,
-        bottom: margins.bottom);
+    return Margins(left: marginLeft, right: marginRight, top: margins.top, bottom: margins.bottom);
   }
 
   @override


### PR DESCRIPTION
Switched to Text.rich form RichText to have textscalefactor applied.
However textscalefactor is applied on each Text.rich recursively, so only apply it to toplevel.