### PR TITLE
Prevent double borders in html table

### DIFF
--- a/packages/flutter_html_table/lib/flutter_html_table.dart
+++ b/packages/flutter_html_table/lib/flutter_html_table.dart
@@ -108,8 +108,7 @@ Widget _layoutCells(RenderContext context, BoxConstraints constraints) {
           rowStart: rowi,
           rowSpan: min(child.rowspan, rows.length - rowi),
           child: CssBoxWidget(
-            style: child.style
-                .merge(row.style), //TODO padding/decoration(color/border)
+            style: row.style, //TODO padding/decoration(color/border)
             child: SizedBox.expand(
               child: Container(
                 alignment: child.style.alignment ??


### PR DESCRIPTION
This merge of style leads to e.g. double borders (when border is used for cell style).