### PR TITLE
fix: improve API for ExtensionContext and export marker.dart

### DIFF
--- a/lib/src/builtins/details_element_builtin.dart
+++ b/lib/src/builtins/details_element_builtin.dart
@@ -23,9 +23,8 @@ class DetailsElementBuiltIn extends HtmlExtension {
   }
 
   @override
-  InlineSpan build(ExtensionContext context,
-      Map<StyledElement, InlineSpan> Function() buildChildren) {
-    final childList = buildChildren();
+  InlineSpan build(ExtensionContext context) {
+    final childList = context.builtChildrenMap!;
     final children = childList.values;
 
     InlineSpan? firstChild = children.isNotEmpty ? children.first : null;

--- a/lib/src/builtins/image_builtin.dart
+++ b/lib/src/builtins/image_builtin.dart
@@ -71,8 +71,7 @@ class ImageBuiltIn extends HtmlExtension {
   }
 
   @override
-  InlineSpan build(ExtensionContext context,
-      Map<StyledElement, InlineSpan> Function() buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     final element = context.styledElement as ImageElement;
 
     final imageStyle = Style(

--- a/lib/src/builtins/interactive_element_builtin.dart
+++ b/lib/src/builtins/interactive_element_builtin.dart
@@ -37,10 +37,9 @@ class InteractiveElementBuiltIn extends HtmlExtension {
   }
 
   @override
-  InlineSpan build(ExtensionContext context,
-      Map<StyledElement, InlineSpan> Function() buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     return TextSpan(
-      children: buildChildren().values.map((childSpan) {
+      children: context.inlineSpanChildren!.map((childSpan) {
         return _processInteractableChild(context, childSpan);
       }).toList(),
     );

--- a/lib/src/builtins/ruby_builtin.dart
+++ b/lib/src/builtins/ruby_builtin.dart
@@ -39,8 +39,7 @@ class RubyBuiltIn extends HtmlExtension {
   }
 
   @override
-  InlineSpan build(ExtensionContext context,
-      Map<StyledElement, InlineSpan> Function() buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     StyledElement? node;
     List<Widget> widgets = <Widget>[];
     final rubySize = context.parser.style['rt']?.fontSize?.value ??

--- a/lib/src/builtins/styled_element_builtin.dart
+++ b/lib/src/builtins/styled_element_builtin.dart
@@ -414,8 +414,7 @@ class StyledElementBuiltIn extends HtmlExtension {
   }
 
   @override
-  InlineSpan build(ExtensionContext context,
-      Map<StyledElement, InlineSpan> Function() buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     if (context.styledElement!.style.display == Display.listItem ||
         ((context.styledElement!.style.display == Display.block ||
                 context.styledElement!.style.display == Display.inlineBlock) &&
@@ -430,8 +429,7 @@ class StyledElementBuiltIn extends HtmlExtension {
           shrinkWrap: context.parser.shrinkWrap,
           childIsReplaced: ["iframe", "img", "video", "audio"]
               .contains(context.styledElement!.name),
-          children: buildChildren()
-              .entries
+          children: context.builtChildrenMap!.entries
               .expandIndexed((i, child) => [
                     child.value,
                     if (context.parser.shrinkWrap &&
@@ -448,8 +446,7 @@ class StyledElementBuiltIn extends HtmlExtension {
 
     return TextSpan(
       style: context.styledElement!.style.generateTextStyle(),
-      children: buildChildren()
-          .entries
+      children: context.builtChildrenMap!.entries
           .expandIndexed((index, child) => [
                 child.value,
                 if (context.parser.shrinkWrap &&

--- a/lib/src/builtins/text_builtin.dart
+++ b/lib/src/builtins/text_builtin.dart
@@ -41,8 +41,7 @@ class TextBuiltIn extends HtmlExtension {
   }
 
   @override
-  InlineSpan build(ExtensionContext context,
-      Map<StyledElement, InlineSpan> Function() buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     if (context.styledElement is LinebreakContentElement) {
       return TextSpan(
         text: '\n',

--- a/lib/src/builtins/vertical_align_builtin.dart
+++ b/lib/src/builtins/vertical_align_builtin.dart
@@ -23,12 +23,12 @@ class VerticalAlignBuiltIn extends HtmlExtension {
   }
 
   @override
-  InlineSpan build(ExtensionContext context, buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     return WidgetSpan(
       child: Transform.translate(
         offset: Offset(0, _getVerticalOffset(context.styledElement!)),
         child: CssBoxWidget.withInlineSpanChildren(
-          children: buildChildren().values.toList(),
+          children: context.inlineSpanChildren!,
           style: context.styledElement!.style,
         ),
       ),

--- a/lib/src/extension/helpers/image_extension.dart
+++ b/lib/src/extension/helpers/image_extension.dart
@@ -59,11 +59,11 @@ class ImageExtension extends ImageBuiltIn {
   }
 
   @override
-  InlineSpan build(ExtensionContext context, buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     if (builder != null) {
       return builder!.call(context);
     } else {
-      return super.build(context, buildChildren);
+      return super.build(context);
     }
   }
 }

--- a/lib/src/extension/helpers/image_tap_extension.dart
+++ b/lib/src/extension/helpers/image_tap_extension.dart
@@ -44,11 +44,13 @@ class OnImageTapExtension extends ImageBuiltIn {
   }
 
   @override
-  InlineSpan build(ExtensionContext context, buildChildren) {
-    final children = buildChildren();
+  InlineSpan build(ExtensionContext context) {
+    final children = context.builtChildrenMap!;
 
-    assert(children.keys.isNotEmpty,
-        "The OnImageTapExtension has been thwarted! It no longer has an `img` child");
+    assert(
+      children.keys.isNotEmpty,
+      "The OnImageTapExtension has been thwarted! It no longer has an `img` child",
+    );
 
     final actualImage = children.keys.first;
 

--- a/lib/src/extension/helpers/matcher_extension.dart
+++ b/lib/src/extension/helpers/matcher_extension.dart
@@ -38,7 +38,7 @@ class MatcherExtension extends HtmlExtension {
   }
 
   @override
-  InlineSpan build(ExtensionContext context, buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     return builder(context);
   }
 }

--- a/lib/src/extension/helpers/tag_extension.dart
+++ b/lib/src/extension/helpers/tag_extension.dart
@@ -45,7 +45,7 @@ class TagExtension extends HtmlExtension {
   Set<String> get supportedTags => tagsToExtend;
 
   @override
-  InlineSpan build(ExtensionContext context, buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     return builder(context);
   }
 }

--- a/lib/src/extension/helpers/tag_wrap_extension.dart
+++ b/lib/src/extension/helpers/tag_wrap_extension.dart
@@ -60,11 +60,10 @@ class TagWrapExtension extends HtmlExtension {
   }
 
   @override
-  InlineSpan build(ExtensionContext context, buildChildren) {
-    final children = buildChildren();
+  InlineSpan build(ExtensionContext context) {
     final child = CssBoxWidget.withInlineSpanChildren(
-      children: children.values.toList(),
-      style: context.styledElement!.style,
+      children: context.inlineSpanChildren!,
+      style: context.style!,
     );
 
     return WidgetSpan(

--- a/lib/src/extension/html_extension.dart
+++ b/lib/src/extension/html_extension.dart
@@ -58,10 +58,10 @@ abstract class HtmlExtension {
   /// The final step in the chain. Converts the StyledElement tree, with its
   /// attached `Style` elements, into an `InlineSpan` tree that includes
   /// Widget/TextSpans that can be rendered in a RichText widget.
-  InlineSpan build(ExtensionContext context,
-      Map<StyledElement, InlineSpan> Function() buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     throw UnimplementedError(
-        "Extension `$runtimeType` matched `${context.styledElement!.name}` but didn't implement `parse`");
+      "Extension `$runtimeType` matched `${context.styledElement!.name}` but didn't implement `parse`",
+    );
   }
 
   /// Called when the Html widget is being destroyed. This would be a very

--- a/lib/src/processing/lists.dart
+++ b/lib/src/processing/lists.dart
@@ -2,7 +2,6 @@ import 'dart:collection';
 
 import 'package:collection/collection.dart';
 import 'package:flutter_html/flutter_html.dart';
-import 'package:flutter_html/src/style/marker.dart';
 import 'package:list_counter/list_counter.dart';
 
 class ListProcessing {

--- a/lib/src/style.dart
+++ b/lib/src/style.dart
@@ -3,7 +3,6 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
 import 'package:flutter_html/src/css_parser.dart';
-import 'package:flutter_html/src/style/marker.dart';
 
 //Export Style value-unit APIs
 export 'package:flutter_html/src/style/margin.dart';
@@ -11,6 +10,7 @@ export 'package:flutter_html/src/style/length.dart';
 export 'package:flutter_html/src/style/size.dart';
 export 'package:flutter_html/src/style/fontsize.dart';
 export 'package:flutter_html/src/style/lineheight.dart';
+export 'package:flutter_html/src/style/marker.dart';
 
 ///This class represents all the available CSS attributes
 ///for this package.

--- a/packages/flutter_html_audio/lib/flutter_html_audio.dart
+++ b/packages/flutter_html_audio/lib/flutter_html_audio.dart
@@ -19,7 +19,7 @@ class AudioHtmlExtension extends HtmlExtension {
   Set<String> get supportedTags => {"audio"};
 
   @override
-  InlineSpan build(ExtensionContext context, buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     return WidgetSpan(
         child: AudioWidget(
       context: context,

--- a/packages/flutter_html_iframe/lib/flutter_html_iframe.dart
+++ b/packages/flutter_html_iframe/lib/flutter_html_iframe.dart
@@ -19,7 +19,7 @@ class IframeHtmlExtension extends HtmlExtension {
   Set<String> get supportedTags => {"iframe"};
 
   @override
-  InlineSpan build(ExtensionContext context, buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     return WidgetSpan(
       child: IframeWidget(
         extensionContext: context,

--- a/packages/flutter_html_math/lib/flutter_html_math.dart
+++ b/packages/flutter_html_math/lib/flutter_html_math.dart
@@ -18,7 +18,7 @@ class MathHtmlExtension extends HtmlExtension {
   Set<String> get supportedTags => {"math"};
 
   @override
-  InlineSpan build(ExtensionContext context, buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     String texStr = _parseMathRecursive(context.styledElement!.element!, '');
     return WidgetSpan(
       child: CssBoxWidget(

--- a/packages/flutter_html_svg/lib/flutter_html_svg.dart
+++ b/packages/flutter_html_svg/lib/flutter_html_svg.dart
@@ -133,7 +133,7 @@ class SvgHtmlExtension extends HtmlExtension {
   }
 
   @override
-  InlineSpan build(ExtensionContext context, buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     late final Widget widget;
 
     if (context.elementName == "svg") {

--- a/packages/flutter_html_table/lib/flutter_html_table.dart
+++ b/packages/flutter_html_table/lib/flutter_html_table.dart
@@ -102,8 +102,7 @@ class TableHtmlExtension extends HtmlExtension {
   }
 
   @override
-  InlineSpan build(ExtensionContext context,
-      Map<StyledElement, InlineSpan> Function() buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     if (context.elementName == "table") {
       return WidgetSpan(
         child: CssBoxWidget(
@@ -112,7 +111,7 @@ class TableHtmlExtension extends HtmlExtension {
             builder: (_, constraints) {
               return _layoutCells(
                 context.styledElement as TableElement,
-                buildChildren(),
+                context.builtChildrenMap!,
                 context,
                 constraints,
               );
@@ -124,7 +123,7 @@ class TableHtmlExtension extends HtmlExtension {
 
     return WidgetSpan(
       child: CssBoxWidget.withInlineSpanChildren(
-        children: buildChildren().values.toList(),
+        children: context.inlineSpanChildren!,
         style: Style(),
       ),
     );

--- a/packages/flutter_html_video/lib/flutter_html_video.dart
+++ b/packages/flutter_html_video/lib/flutter_html_video.dart
@@ -21,7 +21,7 @@ class VideoHtmlExtension extends HtmlExtension {
   Set<String> get supportedTags => {"video"};
 
   @override
-  InlineSpan build(ExtensionContext context, buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     return WidgetSpan(
         child: VideoWidget(
       context: context,

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -217,11 +217,10 @@ class TestExtension extends HtmlExtension {
   }
 
   @override
-  InlineSpan build(ExtensionContext context, buildChildren) {
+  InlineSpan build(ExtensionContext context) {
     finalCallback?.call(context.styledElement!);
     return context.parser.buildFromExtension(
       context,
-      buildChildren,
       extensionsToIgnore: {this},
     );
   }


### PR DESCRIPTION
Fixes #1272 
Fixes #1252 

This simplifies the API for classes extending `HtmlExtension` by moving information about children to the `ExtensionContext`.