### PR TITLE
Mark Summary and Details as block items

### DIFF
--- a/lib/src/builtins/styled_element_builtin.dart
+++ b/lib/src/builtins/styled_element_builtin.dart
@@ -172,11 +172,6 @@ class StyledElementBuiltIn extends HtmlExtension {
           textDecoration: TextDecoration.lineThrough,
         );
         break;
-      case "details":
-        styledElement.style = Style(
-          display: Display.block,
-        );
-        break;
       case "dfn":
         continue italics;
       case "div":

--- a/lib/src/builtins/styled_element_builtin.dart
+++ b/lib/src/builtins/styled_element_builtin.dart
@@ -172,6 +172,11 @@ class StyledElementBuiltIn extends HtmlExtension {
           textDecoration: TextDecoration.lineThrough,
         );
         break;
+      case "details":
+        styledElement.style = Style(
+          display: Display.block,
+        );
+        break;
       case "dfn":
         continue italics;
       case "div":
@@ -390,6 +395,11 @@ class StyledElementBuiltIn extends HtmlExtension {
         styledElement.style = Style(
           fontSize: FontSize.smaller,
           verticalAlign: VerticalAlign.sub,
+        );
+        break;
+      case "summary":
+        styledElement.style = Style(
+          display: Display.block,
         );
         break;
       case "sup":

--- a/test/whitespace_test.dart
+++ b/test/whitespace_test.dart
@@ -66,6 +66,32 @@ void main() {
     },
   );
 
+  //See https://github.com/Sub6Resources/flutter_html/issues/1275
+  testWidgets(
+    "test that extra newlines aren't added unnecessarily for details/summary tags",
+    (tester) async {
+      final tree = await generateStyledElementTreeFromHtml(
+        tester,
+        html: """
+<!DOCTYPE html>
+<html>
+<body>
+<details>
+  <summary><h1>Header</h1></summary>
+  <p>These are the details.</p>
+</details>
+</body>
+</html>
+""",
+      );
+
+      expect(
+          tree.getWhitespace(),
+          equals(
+              "<body><details><summary><h1>Header</h1></summary><p>These◦are◦the◦details.</p></details></body>"));
+    },
+  );
+
   // See https://github.com/Sub6Resources/flutter_html/issues/1251
   testWidgets(
     'test that preserved whitespace is actually preserved',


### PR DESCRIPTION
This fixes issue #1275 and also adds a test case for it.