### PR TITLE
fix: start list items on a new line

### DIFF
--- a/lib/src/builtins/styled_element_builtin.dart
+++ b/lib/src/builtins/styled_element_builtin.dart
@@ -434,7 +434,8 @@ class StyledElementBuiltIn extends HtmlExtension {
                     child.value,
                     if (context.parser.shrinkWrap &&
                         i != context.styledElement!.children.length - 1 &&
-                        child.key.style.display == Display.block &&
+                        (child.key.style.display == Display.block ||
+                            child.key.style.display == Display.listItem) &&
                         child.key.element?.localName != "html" &&
                         child.key.element?.localName != "body")
                       const TextSpan(text: "\n", style: TextStyle(fontSize: 0)),


### PR DESCRIPTION
Each list item is expected to start in a new line (similar to a block element). Otherwise list items will overlap with each other in a list when `shrinkWrap` is enabled.

fixes #1280