### PR TITLE
feat: Implement flutter_html_code extension

### DIFF
--- a/packages/flutter_html_code/.gitignore
+++ b/packages/flutter_html_code/.gitignore
@@ -1,0 +1,77 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+pubspec.lock
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.pub-cache/
+.pub/
+build/
+coverage/
+
+# Android related
+**/android/**/gradle-wrapper.jar
+**/android/.gradle
+**/android/captures/
+**/android/gradlew
+**/android/gradlew.bat
+**/android/local.properties
+**/android/**/GeneratedPluginRegistrant.java
+
+# iOS/XCode related
+**/ios/**/*.mode1v3
+**/ios/**/*.mode2v3
+**/ios/**/*.moved-aside
+**/ios/**/*.pbxuser
+**/ios/**/*.perspectivev3
+**/ios/**/*sync/
+**/ios/**/.sconsign.dblite
+**/ios/**/.tags*
+**/ios/**/.vagrant/
+**/ios/**/DerivedData/
+**/ios/**/Icon?
+**/ios/**/Pods/
+**/ios/**/.symlinks/
+**/ios/**/profile
+**/ios/**/xcuserdata
+**/ios/.generated/
+**/ios/Flutter/App.framework
+**/ios/Flutter/Flutter.framework
+**/ios/Flutter/Flutter.podspec
+**/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/ephemeral
+**/ios/Flutter/app.flx
+**/ios/Flutter/app.zip
+**/ios/Flutter/flutter_assets/
+**/ios/Flutter/flutter_export_environment.sh
+**/ios/ServiceDefinitions.json
+**/ios/Runner/GeneratedPluginRegistrant.*
+
+# Exceptions to above rules.
+!**/ios/**/default.mode1v3
+!**/ios/**/default.mode2v3
+!**/ios/**/default.pbxuser
+!**/ios/**/default.perspectivev3

--- a/packages/flutter_html_code/CHANGELOG.md
+++ b/packages/flutter_html_code/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 3.0.0
+
+Initial commit

--- a/packages/flutter_html_code/LICENSE
+++ b/packages/flutter_html_code/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019-2022 The flutter_html developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/flutter_html_code/README.md
+++ b/packages/flutter_html_code/README.md
@@ -1,0 +1,19 @@
+# flutter_html_code
+
+Code widget for flutter_html. Uses the [flutter_highlighter](https://pub.dev/packages/flutter_highlighter) package
+to render `<code>` blocks. Detects the language from the attribute or uses the `defaultLanguage`.
+
+#### Registering the `CodeExtension`:
+
+```dart
+Widget html = Html(
+    extensions: [
+        CodeExtension(
+            style: TextStyle(fontSize: 16),
+            theme: shadesOfPurpleTheme,
+            borderRadius: BorderRadius.circular(4),
+            defaultLanguage: html,
+        ),
+    ],
+);
+```

--- a/packages/flutter_html_code/analysis_options.yaml
+++ b/packages/flutter_html_code/analysis_options.yaml
@@ -1,0 +1,29 @@
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
+# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
+# invoked from the command line by running `flutter analyze`.
+
+# The following line activates a set of recommended lints for Flutter apps,
+# packages, and plugins designed to encourage good coding practices.
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  # The lint rules applied to this project can be customized in the
+  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
+  # included above or to enable additional rules. A list of all available lints
+  # and their documentation is published at
+  # https://dart-lang.github.io/linter/lints/index.html.
+  #
+  # Instead of disabling a lint rule for the entire project in the
+  # section below, it can also be suppressed for a single line of code
+  # or a specific dart file by using the `// ignore: name_of_lint` and
+  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
+  # producing the lint.
+  rules:
+  # avoid_print: false  # Uncomment to disable the `avoid_print` rule
+  # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/packages/flutter_html_code/example/example.md
+++ b/packages/flutter_html_code/example/example.md
@@ -1,0 +1,3 @@
+# Example
+
+### Coming soon...

--- a/packages/flutter_html_code/lib/flutter_html_code.dart
+++ b/packages/flutter_html_code/lib/flutter_html_code.dart
@@ -1,0 +1,59 @@
+library flutter_html_code;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_highlighter/flutter_highlighter.dart';
+import 'package:collection/collection.dart';
+
+class CodeExtension extends HtmlExtension {
+  final TextStyle? style;
+  final Map<String, TextStyle> theme;
+  final EdgeInsets? padding;
+  final BorderRadius? borderRadius;
+  final String? defaultLanguage;
+
+  CodeExtension({
+    this.style,
+    this.theme = const {},
+    this.padding,
+    this.borderRadius,
+    this.defaultLanguage,
+  });
+
+  @override
+  Set<String> get supportedTags => {'code'};
+
+  @override
+  InlineSpan build(
+    ExtensionContext context,
+    Map<StyledElement, InlineSpan> Function() parseChildren,
+  ) =>
+      WidgetSpan(
+        child: Material(
+          clipBehavior: Clip.hardEdge,
+          borderRadius: borderRadius ?? BorderRadius.circular(4),
+          child: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: HighlightView(
+              context.element?.text ?? '',
+              language: context.element?.className
+                      .split(' ')
+                      .singleWhereOrNull(
+                        (className) => className.startsWith('language-'),
+                      )
+                      ?.split('language-')
+                      .last ??
+                  defaultLanguage,
+              theme: theme,
+              padding: padding ??
+                  EdgeInsets.symmetric(
+                    horizontal: 6,
+                    vertical:
+                        context.element?.parent?.localName == 'pre' ? 6 : 0,
+                  ),
+              textStyle: style,
+            ),
+          ),
+        ),
+      );
+}

--- a/packages/flutter_html_code/pubspec.yaml
+++ b/packages/flutter_html_code/pubspec.yaml
@@ -1,0 +1,31 @@
+name: flutter_html_code
+description: This extension package allows the <code> tag with syntax highlighting to be rendered using the flutter_html package
+version: 3.0.0-beta.1
+homepage: https://github.com/Sub6Resources/flutter_html
+
+environment:
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=2.2.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+  html: ">=0.15.0 <1.0.0"
+  flutter_highlighter: ^0.1.1
+  flutter_html: ^3.0.0-beta.1
+  collection: ^1.17.1
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.1
+  meta: ^1.8.0
+
+funding:
+  - https://opencollective.com/flutter_html
+
+topics:
+  - html
+  - css
+  - code
+  - flutter_html


### PR DESCRIPTION
This is my attempt to contribute an official extension. Just uses the flutter_highlighter package to render nice code blocks. I have this already in use in two of my Flutter apps :)