### PR TITLE
Add srcdoc, controller, and properties to iframe package

### DIFF
--- a/packages/flutter_html_iframe/lib/flutter_html_iframe.dart
+++ b/packages/flutter_html_iframe/lib/flutter_html_iframe.dart
@@ -10,9 +10,11 @@ import 'iframe_unsupported.dart'
 
 class IframeHtmlExtension extends HtmlExtension {
   final NavigationDelegate? navigationDelegate;
+  final WebViewController? controller;
 
   const IframeHtmlExtension({
     this.navigationDelegate,
+    this.controller,
   });
 
   @override
@@ -24,6 +26,7 @@ class IframeHtmlExtension extends HtmlExtension {
       child: IframeWidget(
         extensionContext: context,
         navigationDelegate: navigationDelegate,
+        controller: controller,
       ),
     );
   }

--- a/packages/flutter_html_iframe/lib/flutter_html_iframe.dart
+++ b/packages/flutter_html_iframe/lib/flutter_html_iframe.dart
@@ -1,8 +1,9 @@
 library flutter_html_iframe;
 
 import 'package:flutter/widgets.dart';
-import 'package:flutter_html/flutter_html.dart';
 import 'package:webview_flutter/webview_flutter.dart';
+
+import 'package:flutter_html/flutter_html.dart';
 
 import 'iframe_unsupported.dart'
     if (dart.library.io) 'iframe_mobile.dart'
@@ -11,10 +12,12 @@ import 'iframe_unsupported.dart'
 class IframeHtmlExtension extends HtmlExtension {
   final NavigationDelegate? navigationDelegate;
   final WebViewController? controller;
+  final IframeProperties? iframeProperties;
 
   const IframeHtmlExtension({
     this.navigationDelegate,
     this.controller,
+    this.iframeProperties,
   });
 
   @override
@@ -27,7 +30,18 @@ class IframeHtmlExtension extends HtmlExtension {
         extensionContext: context,
         navigationDelegate: navigationDelegate,
         controller: controller,
+        iframeProperties: iframeProperties,
       ),
     );
   }
+}
+
+class IframeProperties {
+  double? height;
+  double? width;
+
+  IframeProperties({this.height, this.width});
+
+  @override
+  String toString() => 'IframeProperties(height: $height, width: $width)';
 }

--- a/packages/flutter_html_iframe/lib/iframe_mobile.dart
+++ b/packages/flutter_html_iframe/lib/iframe_mobile.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -34,6 +36,18 @@ class IframeWidget extends StatelessWidget {
     final givenHeight =
         double.tryParse(extensionContext.attributes['height'] ?? "");
 
+    Uri? srcUri;
+
+    if (extensionContext.attributes['srcdoc'] != null) {
+      srcUri = Uri.dataFromString(
+        extensionContext.attributes['srcdoc'] ?? '',
+        mimeType: 'text/html',
+        encoding: Encoding.getByName('utf-8'),
+      );
+    } else {
+      srcUri = Uri.tryParse(extensionContext.attributes['src'] ?? "") ?? Uri();
+    }
+
     return SizedBox(
       width: givenWidth ?? (givenHeight ?? 150) * 2,
       height: givenHeight ?? (givenWidth ?? 300) / 2,
@@ -41,10 +55,7 @@ class IframeWidget extends StatelessWidget {
         style: extensionContext.styledElement!.style,
         childIsReplaced: true,
         child: WebViewWidget(
-          controller: controller
-            ..loadRequest(
-                Uri.tryParse(extensionContext.attributes['src'] ?? "") ??
-                    Uri()),
+          controller: controller..loadRequest(srcUri),
           key: key,
           gestureRecognizers: {Factory(() => VerticalDragGestureRecognizer())},
         ),

--- a/packages/flutter_html_iframe/lib/iframe_mobile.dart
+++ b/packages/flutter_html_iframe/lib/iframe_mobile.dart
@@ -4,29 +4,31 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_html_iframe/flutter_html_iframe.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 class IframeWidget extends StatelessWidget {
   final NavigationDelegate? navigationDelegate;
   final ExtensionContext extensionContext;
   final WebViewController? controller;
+  final IframeProperties? iframeProperties;
 
   const IframeWidget({
     Key? key,
     required this.extensionContext,
     this.navigationDelegate,
     this.controller,
+    this.iframeProperties,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    WebViewController controller = WebViewController();
-
     final sandboxMode = extensionContext.attributes["sandbox"];
+
     // The decision here was to allow the developer to have full control over the
     // WebViewController they have passed in and to NOT override the JavaScriptMode
     // they might have already set.
-    controller = this.controller ?? WebViewController()
+    WebViewController controller = this.controller ?? WebViewController()
       ..setJavaScriptMode(sandboxMode == null || sandboxMode == "allow-scripts"
           ? JavaScriptMode.unrestricted
           : JavaScriptMode.disabled);
@@ -36,9 +38,10 @@ class IframeWidget extends StatelessWidget {
     }
 
     final UniqueKey key = UniqueKey();
-    final givenWidth =
+
+    final givenWidth = iframeProperties?.width ??
         double.tryParse(extensionContext.attributes['width'] ?? "");
-    final givenHeight =
+    final givenHeight = iframeProperties?.height ??
         double.tryParse(extensionContext.attributes['height'] ?? "");
 
     Uri? srcUri;

--- a/packages/flutter_html_iframe/lib/iframe_mobile.dart
+++ b/packages/flutter_html_iframe/lib/iframe_mobile.dart
@@ -9,22 +9,27 @@ import 'package:webview_flutter/webview_flutter.dart';
 class IframeWidget extends StatelessWidget {
   final NavigationDelegate? navigationDelegate;
   final ExtensionContext extensionContext;
+  final WebViewController? controller;
 
   const IframeWidget({
     Key? key,
     required this.extensionContext,
     this.navigationDelegate,
+    this.controller,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final WebViewController controller = WebViewController();
+    WebViewController controller = WebViewController();
 
     final sandboxMode = extensionContext.attributes["sandbox"];
-    controller.setJavaScriptMode(
-        sandboxMode == null || sandboxMode == "allow-scripts"
-            ? JavaScriptMode.unrestricted
-            : JavaScriptMode.disabled);
+    // The decision here was to allow the developer to have full control over the
+    // WebViewController they have passed in and to NOT override the JavaScriptMode
+    // they might have already set.
+    controller = this.controller ?? WebViewController()
+      ..setJavaScriptMode(sandboxMode == null || sandboxMode == "allow-scripts"
+          ? JavaScriptMode.unrestricted
+          : JavaScriptMode.disabled);
 
     if (navigationDelegate != null) {
       controller.setNavigationDelegate(navigationDelegate!);

--- a/packages/flutter_html_iframe/lib/iframe_unsupported.dart
+++ b/packages/flutter_html_iframe/lib/iframe_unsupported.dart
@@ -7,6 +7,7 @@ class IframeWidget extends StatelessWidget {
     Key? key,
     required ExtensionContext? extensionContext,
     NavigationDelegate? navigationDelegate,
+    WebViewController? controller,
   }) : super(key: key);
 
   @override

--- a/packages/flutter_html_iframe/lib/iframe_unsupported.dart
+++ b/packages/flutter_html_iframe/lib/iframe_unsupported.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_html_iframe/flutter_html_iframe.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
 class IframeWidget extends StatelessWidget {
@@ -8,6 +9,7 @@ class IframeWidget extends StatelessWidget {
     required ExtensionContext? extensionContext,
     NavigationDelegate? navigationDelegate,
     WebViewController? controller,
+    IframeProperties? iframeProperties,
   }) : super(key: key);
 
   @override

--- a/packages/flutter_html_iframe/lib/iframe_web.dart
+++ b/packages/flutter_html_iframe/lib/iframe_web.dart
@@ -28,6 +28,7 @@ class IframeWidget extends StatelessWidget {
     final html.IFrameElement iframe = html.IFrameElement()
       ..width = (givenWidth ?? (givenHeight ?? 150) * 2).toString()
       ..height = (givenHeight ?? (givenWidth ?? 300) / 2).toString()
+      ..srcdoc = extensionContext.attributes['srcdoc']
       ..src = extensionContext.attributes['src']
       ..style.border = 'none';
     final String createdViewId = _getRandString(10);

--- a/packages/flutter_html_iframe/lib/iframe_web.dart
+++ b/packages/flutter_html_iframe/lib/iframe_web.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
+import 'package:flutter_html_iframe/flutter_html_iframe.dart';
 import 'package:flutter_html_iframe/shims/dart_ui.dart' as ui;
 // ignore: avoid_web_libraries_in_flutter
 import 'dart:html' as html;
@@ -12,11 +13,13 @@ import 'package:webview_flutter/webview_flutter.dart';
 class IframeWidget extends StatelessWidget {
   final NavigationDelegate? navigationDelegate;
   final ExtensionContext extensionContext;
+  final IframeProperties? iframeProperties;
 
   const IframeWidget({
     Key? key,
     required this.extensionContext,
     this.navigationDelegate,
+    this.iframeProperties,
   }) : super(key: key);
 
   @override
@@ -26,8 +29,10 @@ class IframeWidget extends StatelessWidget {
     final givenHeight =
         double.tryParse(extensionContext.attributes['height'] ?? "");
     final html.IFrameElement iframe = html.IFrameElement()
-      ..width = (givenWidth ?? (givenHeight ?? 150) * 2).toString()
-      ..height = (givenHeight ?? (givenWidth ?? 300) / 2).toString()
+      ..width = iframeProperties?.width.toString() ??
+          (givenWidth ?? (givenHeight ?? 150) * 2).toString()
+      ..height = iframeProperties?.height.toString() ??
+          (givenHeight ?? (givenWidth ?? 300) / 2).toString()
       ..srcdoc = extensionContext.attributes['srcdoc']
       ..src = extensionContext.attributes['src']
       ..style.border = 'none';


### PR DESCRIPTION
This branch allows developers to, in addition to 'src', pass in html that contains a 'srcdoc' property. 'src' is great for passing in a URL, but if someone wants to pass in HTML, etc., inside an iframe, then we need to use 'srcdoc'. This branch is broken into three commits since there are three separate features being introduced.

1. Check is 'srcdoc' is sent in with the extensionContext attributes. If there is no 'srcdoc' we fallback to 'src'. This change doesn't break the current usage of the package and will not impact developers currently using it.
2. Add an optional WebViewController to be passed in when constructing the IframeWidget. This would allow developers to have more control over what the WebViewController can do.
3. Add IframeProperties class that has a width and height. Add an optional IframeProperties parameter to be passed in when constructing the IframeWidget. This would allow developers the control to set the width and height of the iframe.

Full disclosure: These changes solve an issue for me. I need to use 'srcdoc' to pass in HTML that also contains some JavaScript. The JavaScript has a method that can send a message back to the WebViewController through its .addJavaScriptChannel parameter. I use that to send the height of the iframe after it is loaded which I then pass back in through the IframeProperties. Without this, the iframe loads THEN the JavaScript run and the height of the iframe content changes but the Flutter widget remains too small to display the full content. 