### PR TITLE
Add srcdoc check when building IframeWidget

### DIFF
--- a/packages/flutter_html_iframe/lib/iframe_mobile.dart
+++ b/packages/flutter_html_iframe/lib/iframe_mobile.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -34,6 +36,18 @@ class IframeWidget extends StatelessWidget {
     final givenHeight =
         double.tryParse(extensionContext.attributes['height'] ?? "");
 
+    Uri? srcUri;
+
+    if (extensionContext.attributes['srcdoc'] != null) {
+      srcUri = Uri.dataFromString(
+        extensionContext.attributes['srcdoc'] ?? '',
+        mimeType: 'text/html',
+        encoding: Encoding.getByName('utf-8'),
+      );
+    } else {
+      srcUri = Uri.tryParse(extensionContext.attributes['src'] ?? "") ?? Uri();
+    }
+
     return SizedBox(
       width: givenWidth ?? (givenHeight ?? 150) * 2,
       height: givenHeight ?? (givenWidth ?? 300) / 2,
@@ -41,10 +55,7 @@ class IframeWidget extends StatelessWidget {
         style: extensionContext.styledElement!.style,
         childIsReplaced: true,
         child: WebViewWidget(
-          controller: controller
-            ..loadRequest(
-                Uri.tryParse(extensionContext.attributes['src'] ?? "") ??
-                    Uri()),
+          controller: controller..loadRequest(srcUri),
           key: key,
           gestureRecognizers: {Factory(() => VerticalDragGestureRecognizer())},
         ),


### PR DESCRIPTION
This branch allows developers to, in addition to 'src', pass in html that contains a 'srcdoc' property. 'src' is great for passing in a URL, but if someone wants to pass in HTML, etc., inside an iframe, then we need to use 'srcdoc'. This branch is broken into three commits since there are three separate features being introduced.

Check is 'srcdoc' is sent in with the extensionContext attributes. If there is no 'srcdoc' we fallback to 'src'. This change doesn't break the current usage of the package and will not impact developers currently using it.