### PR TITLE
Using disc as default list style if the specified one doesn't exist

### DIFF
--- a/lib/src/style.dart
+++ b/lib/src/style.dart
@@ -664,7 +664,7 @@ enum ListStyleType {
   factory ListStyleType.fromName(String name) {
     return ListStyleType.values.firstWhere((value) {
       return name == value.counterStyle;
-    });
+    }, orElse: () => ListStyleType.disc);
   }
 }
 


### PR DESCRIPTION
This was causing a exception and not properly displaying the widget