### PR TITLE
fix: enable JavaScript in iframe

### DIFF
--- a/packages/flutter_html_iframe/lib/iframe_mobile.dart
+++ b/packages/flutter_html_iframe/lib/iframe_mobile.dart
@@ -20,7 +20,7 @@ class IframeWidget extends StatelessWidget {
 
     final sandboxMode = extensionContext.attributes["sandbox"];
     controller.setJavaScriptMode(
-        sandboxMode == null || sandboxMode == "allow-scripts"
+        sandboxMode == null || sandboxMode.contains("allow-scripts")
             ? JavaScriptMode.unrestricted
             : JavaScriptMode.disabled);
 


### PR DESCRIPTION
When an iframe contains the `sandbox` attribute, its value must be exactly `allow-scripts` in order to enable JavaScript. However, in many cases the attribute has more than one value. Here is an example:[^1]

```
sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
```

We make the condition more flexible by using `contains`.

Fixes https://github.com/DocMarty84/miniflutt/issues/30

[^1]: https://github.com/miniflux/v2/blob/3388f8e376632da49be8d8785422962ba83a8518/internal/reader/sanitizer/sanitizer.go#L238