### PR TITLE
Resolve: [BUG]':hover' selector of type PseudoClassSelector is not implemented

### DIFF
--- a/lib/src/tree/styled_element.dart
+++ b/lib/src/tree/styled_element.dart
@@ -4,7 +4,7 @@ import 'package:flutter_html/src/style.dart';
 import 'package:html/dom.dart' as dom;
 //TODO(Sub6Resources): don't use the internal code of the html package as it may change unexpectedly.
 //ignore: implementation_imports
-import 'package:html/src/query_selector.dart';
+import 'package:html/src/query_selector.dart' as qs;
 import 'package:list_counter/list_counter.dart';
 
 /// A [StyledElement] applies a style to all of its children.
@@ -26,6 +26,14 @@ class StyledElement {
     required this.node,
   });
 
+  bool matches(dom.Element element, String selector) {
+    try {
+      return qs.matches(element, selector);
+    } catch (_) {
+      return false;
+    }
+  }
+  
   bool matchesSelector(String selector) {
     return (element != null && matches(element!, selector)) || name == selector;
   }


### PR DESCRIPTION
The issue should be fixed on the html side, really; throwing errors looks too excessive to me. Ignoring it is also not the best solution, but it looks better than crashing the widget. 

Resolves https://github.com/Sub6Resources/flutter_html/issues/1298