### PR TITLE
feature/a-href-overridable-style

### DIFF
--- a/lib/src/builtins/interactive_element_builtin.dart
+++ b/lib/src/builtins/interactive_element_builtin.dart
@@ -61,7 +61,7 @@ class InteractiveElementBuiltIn extends HtmlExtension {
         children: childSpan.children
             ?.map((e) => _processInteractableChild(context, e))
             .toList(),
-        style: childSpan.style,
+        style: context.styledElement?.style.generateTextStyle() ?? childSpan.style,
         semanticsLabel: childSpan.semanticsLabel,
         recognizer: TapGestureRecognizer()..onTap = onTap,
       );


### PR DESCRIPTION
This PR make a tag style be overrided.

```dart
  "a": Style.fromTextStyle(
          const TextStyle(
            color: Colors.black,
            fontWeight: FontWeight.bold,
            decoration: TextDecoration.underline,
            decorationThickness: 4,
            decorationColor: Color(0xFFFCFC03),
          ),
        ),
```

Before :
![image](https://github.com/user-attachments/assets/8f8ae10e-2f11-4744-939c-a4ff4a51644c)

After : 
![image](https://github.com/user-attachments/assets/80fd74bc-b3ee-497f-a4d4-a56376339018)
